### PR TITLE
fix(init): add defensive error handling for edge cases

### DIFF
--- a/src/systems/features/htmlCleaning.js
+++ b/src/systems/features/htmlCleaning.js
@@ -4,6 +4,37 @@
  */
 
 /**
+ * Detects old manual regex formatters that might conflict with the extension
+ * @param {Object} st_extension_settings - SillyTavern extension settings object
+ * @returns {Array<string>} Array of conflicting regex script names
+ */
+export function detectConflictingRegexScripts(st_extension_settings) {
+    const conflictingNames = [
+        'Format User\'s Stats (Only Output)',
+        'Format User\'s Stats (Only Display)',
+        'Format Info Box (Only Output)',
+        'Format Info Box (Only Display)',
+        'Format Character\'s Thoughts (Only Output)',
+        'Format Character\'s Thoughts (Only Display)',
+        'Format Character Thoughts (Only Output)',
+        'Format Character Thoughts (Only Display)'
+    ];
+
+    const existingScripts = st_extension_settings?.regex || [];
+    const conflicts = [];
+
+    for (const script of existingScripts) {
+        if (script && script.scriptName && conflictingNames.some(name =>
+            script.scriptName.toLowerCase().includes(name.toLowerCase())
+        )) {
+            conflicts.push(script.scriptName);
+        }
+    }
+
+    return conflicts;
+}
+
+/**
  * Automatically imports the HTML cleaning regex script if it doesn't already exist.
  * This regex removes HTML tags from outgoing prompts to prevent formatting issues.
  * @param {Object} st_extension_settings - SillyTavern extension settings object
@@ -11,10 +42,25 @@
  */
 export async function ensureHtmlCleaningRegex(st_extension_settings, saveSettingsDebounced) {
     try {
+        // Validate extension settings structure
+        if (!st_extension_settings || typeof st_extension_settings !== 'object') {
+            console.warn('[RPG Companion] Invalid extension_settings object, skipping HTML regex import');
+            return;
+        }
+
         // Check if the HTML cleaning regex already exists
         const scriptName = 'Clean HTML (From Outgoing Prompt)';
         const existingScripts = st_extension_settings?.regex || [];
-        const alreadyExists = existingScripts.some(script => script.scriptName === scriptName);
+
+        // Validate regex array
+        if (!Array.isArray(existingScripts)) {
+            console.warn('[RPG Companion] extension_settings.regex is not an array, resetting to empty array');
+            st_extension_settings.regex = [];
+        }
+
+        const alreadyExists = existingScripts.some(script =>
+            script && typeof script === 'object' && script.scriptName === scriptName
+        );
 
         if (alreadyExists) {
             console.log('[RPG Companion] HTML cleaning regex already exists, skipping import');
@@ -55,11 +101,16 @@ export async function ensureHtmlCleaningRegex(st_extension_settings, saveSetting
         st_extension_settings.regex.push(regexScript);
 
         // Save the changes using the already-imported function
-        saveSettingsDebounced();
+        if (typeof saveSettingsDebounced === 'function') {
+            saveSettingsDebounced();
+        } else {
+            console.warn('[RPG Companion] saveSettingsDebounced is not a function, cannot save HTML regex');
+        }
 
         console.log('[RPG Companion] ✅ HTML cleaning regex imported successfully');
     } catch (error) {
         console.error('[RPG Companion] Failed to import HTML cleaning regex:', error);
+        console.error('[RPG Companion] Error details:', error.message, error.stack);
         // Don't throw - this is a nice-to-have feature
     }
 }

--- a/style.css
+++ b/style.css
@@ -2866,7 +2866,7 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
     background: var(--rpg-highlight, #e94560);
     color: white;
     border: 2px solid var(--rpg-bg, rgba(30, 30, 50, 0.95));
-    font-size: 1.7vw;
+    font-size: clamp(0.9rem, 1rem, 1.1rem);
     line-height: 1;
     cursor: pointer;
     display: flex;
@@ -2894,7 +2894,7 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.85vw;
+    font-size: clamp(1.3rem, 1.4rem, 1.5rem);
     cursor: pointer;
     animation: thoughtIconPulse 2s ease-in-out infinite;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
@@ -3016,7 +3016,7 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
 /* Thought content on the right */
 .rpg-thought-content {
     flex: 1;
-    font-size: clamp(0.68vw, 0.7vw, 0.72vw);
+    font-size: clamp(0.85rem, 0.9rem, 0.95rem);
     line-height: 1.5;
     color: var(--rpg-text, #eaeaea);
     font-style: italic;


### PR DESCRIPTION
## Fix: Defensive error handling for edge cases

Adds robust error handling to prevent the extension from completely failing to load when encountering unexpected settings configurations.

### What happened
User reported extension wouldn't load at all with their settings.json - narrowed down to something in their `extension_settings` breaking initialization. A fresh install worked fine, suggesting corrupted or incompatible data.

### What changed
- Added settings validation in `loadSettings()` to detect corrupt data
- Wrapped each init step in independent try-catch blocks (settings, UI, events, etc.)
- Enhanced HTML regex import with structure validation
- Added detection for old manual formatting regexes that conflict with the extension
- Added user-friendly toastr notifications for errors and conflicts
- Extension now gracefully falls back to defaults instead of dying completely

### Testing
- Extension now loads even with malformed settings
- Warns users about conflicting old regex scripts
- Each component fails independently without cascading failures
- Detailed console logging for debugging edge cases

Should prevent similar "extension won't load at all" issues in the future 🎉

Thanks to Tower for helping me debug the issue!