### PR TITLE
fix: Render chat messages using updateMessageBlock

### DIFF
--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -4,7 +4,7 @@
  */
 
 import { getContext } from '../../../../../../extensions.js';
-import { chat, user_avatar, setExtensionPrompt, extension_prompt_types } from '../../../../../../../script.js';
+import { chat, user_avatar, setExtensionPrompt, extension_prompt_types, updateMessageBlock } from '../../../../../../../script.js';
 
 // Core modules
 import {
@@ -167,13 +167,9 @@ export async function onMessageReceived(data) {
             renderQuests();
 
             // Then update the DOM to reflect the cleaned message
-            const lastMessageElement = $('#chat').children('.mes').last();
-            if (lastMessageElement.length) {
-                const messageText = lastMessageElement.find('.mes_text');
-                if (messageText.length) {
-                    messageText.html(substituteParams(cleanedMessage.trim()));
-                }
-            }
+            // Using updateMessageBlock to perform macro substitutions + regex formatting
+            const messageId = chat.length - 1;
+            updateMessageBlock(messageId, lastMessage, { rerenderMessage: true });
 
             // console.log('[RPG Companion] Cleaned message, removed tracker code blocks from DOM');
 
@@ -255,9 +251,9 @@ export function onMessageSwiped(messageIndex) {
     // Only set flag to true if this swipe will trigger a NEW generation
     // Check if the swipe already exists (has content in the swipes array)
     const isExistingSwipe = message.swipes &&
-                           message.swipes[currentSwipeId] !== undefined &&
-                           message.swipes[currentSwipeId] !== null &&
-                           message.swipes[currentSwipeId].length > 0;
+        message.swipes[currentSwipeId] !== undefined &&
+        message.swipes[currentSwipeId] !== null &&
+        message.swipes[currentSwipeId].length > 0;
 
     if (!isExistingSwipe) {
         // This is a NEW swipe that will trigger generation


### PR DESCRIPTION
# Problem

Currently cleaning up the message was leading to unhandled exception due to calling `substituteParams` without import. 

<img width="1561" height="191" alt="image" src="https://github.com/user-attachments/assets/05c67512-4225-433a-bdfb-79e3af79a954" />

This led to messages not being able to be rendered properly without having to click the edit button.

# Solution

Call `updateMessageBlock` in order to both call the proper macro substitution that `substituteParams` was doing to replace `{{user}}` and `{{char}}` but also leverage `updateMessageBlock` formatting and regex calls. 

# Tests

## Before:

<img width="978" height="935" alt="image" src="https://github.com/user-attachments/assets/f4ffb246-1f15-4517-987f-b3dc2d307f5a" />


## After:

<img width="945" height="395" alt="image" src="https://github.com/user-attachments/assets/61209b25-075f-4e22-b408-3d2efa06fa44" />

Also no more traces shown in console. 

Second screenshot to show no regression to tracker

<img width="1767" height="1262" alt="image" src="https://github.com/user-attachments/assets/432a604f-af93-4f61-9b7e-305333cd4caa" />

