### PR TITLE
fix: some mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -943,7 +943,7 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
     display: flex;
     align-items: center;
     gap: 0.375em;
-    font-size: clamp(11px, 0.5vw, 14px);
+    font-size: clamp(0.4vw, 0.5vw, 0.6vw);
     padding: clamp(4px, 0.6vh, 6px) 0.375em;
     background: rgba(0, 0, 0, 0.3);
     border-radius: 0.25em;
@@ -5216,6 +5216,11 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
 
     .rpg-classic-stat-btn:active {
         transform: scale(0.95);
+    }
+
+    .rpg-skills-section {
+        font-size: clamp(11px, 2.8vw, 14px);
+        line-height: 1.3;
     }
 
     /* ========================================


### PR DESCRIPTION
Fixes these problems on mobile screen:

- The quests tab is partially off screen. (#46)
- The info box layout is broken. (#46)
- The skill section font size is too small.
- Cannot see RPG classic stats section.