### PR TITLE
fix: Swipes hanging due race condition when handling promises in chapterCheckpoints

### DIFF
--- a/src/systems/features/chapterCheckpoint.js
+++ b/src/systems/features/chapterCheckpoint.js
@@ -14,7 +14,7 @@ let currentlyHiddenRange = null;
 // Debounce restore to prevent loops
 let isRestoring = false;
 let restoreTimeout = null;
-let pendingResolve = null; // Track pending promise resolve function
+let pendingResolve = null;
 
 /**
  * Gets the current chapter checkpoint message ID for the active chat
@@ -142,7 +142,7 @@ export async function restoreCheckpointOnLoad() {
 
     // Debounce: wait 100ms before actually restoring
     return new Promise((resolve) => {
-        pendingResolve = resolve; // Track this promise's resolve function
+        pendingResolve = resolve;
         restoreTimeout = setTimeout(async () => {
             isRestoring = true;
             try {


### PR DESCRIPTION
# Context

Pulled latest and noticed that swipes kept hanging after the chapterCheckpoint feature was added. It seems that promises weren't being resolved properly as timing is different for normal messages vs swipes. 

## Problem

There appears to be a race condition in which calling event handlers for `restoreCheckpointOnLoad` is called multiple times under the debounce threshold which causes the last call to clear call `clearTimeout` function which clears the first call's timer without resolving the promise. This causes the promise to wait forever and hangs the chat infinitively on swipes. This may be due to the timing in which the events `MESSAGE_RECEIVED` and `GENERATION_ENDED` are called back to back for swipes as opposed to normal chats. 

## Solution

If there's multiple calls to `restoreCheckpointOnLoad` we need to track their state `timer/resolution` independently to avoid permanently hanging. 

# Test

Mostly debugged with log messages but removed for PR. I made recordings of before/after so you can test the steps I did myself.

On main branch:
1. Start a chat with RPG Companion enabled
2. Send message
3. Swipe message

Then repeat on my branch, ultimately since this is a timing issue due to the back to back event calls, this may not be 100% reproducible as other extensions may also interfere with the timing. 

## Before fix

[before_swipe_fix.webm](https://github.com/user-attachments/assets/f07e4114-3f47-4137-983f-9ad3202a2aeb)

## After fix

[after_swipe_fix.webm](https://github.com/user-attachments/assets/75103ac3-d8a4-4e3f-a4fe-f5dec210dcfd)
