### PR TITLE
Fixed auto updating with external api mode

### DIFF
--- a/src/systems/generation/injector.js
+++ b/src/systems/generation/injector.js
@@ -78,11 +78,11 @@ export async function onGenerationStarted(type, data) {
 
     const lastMessage = chat && chat.length > 0 ? chat[chat.length - 1] : null;
 
-    // For SEPARATE mode only: Check if we need to commit extension data
+    // For SEPARATE/EXTERNAL mode: Check if we need to commit extension data
     // BUT: Only do this for the MAIN generation, not the tracker update generation
     // If isGenerating is true, this is the tracker update generation (second call), so skip flag logic
     // console.log('[RPG Companion DEBUG] Before generating:', lastGeneratedData.characterThoughts, ' , committed - ', committedTrackerData.characterThoughts);
-    if (extensionSettings.generationMode === 'separate' && !isGenerating) {
+    if ((extensionSettings.generationMode === 'separate' || extensionSettings.generationMode === 'external') && !isGenerating) {
         if (!lastActionWasSwipe) {
             // User sent a new message - commit lastGeneratedData before generation
             // console.log('[RPG Companion] 📝 COMMIT: New message - committing lastGeneratedData');
@@ -246,8 +246,8 @@ export async function onGenerationStarted(type, data) {
             // Clear Spotify prompt if disabled
             setExtensionPrompt('rpg-companion-spotify', '', extension_prompt_types.IN_CHAT, 0, false);
         }
-    } else if (extensionSettings.generationMode === 'separate') {
-        // In SEPARATE mode, inject the contextual summary for main roleplay generation
+    } else if (extensionSettings.generationMode === 'separate' || extensionSettings.generationMode === 'external') {
+        // In SEPARATE/EXTERNAL mode, inject the contextual summary for main roleplay generation
         const contextSummary = generateContextualSummary();
 
         if (contextSummary) {

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -89,8 +89,8 @@ export function onMessageSent() {
     setLastActionWasSwipe(false);
     // console.log('[RPG Companion] 🟢 EVENT: onMessageSent - lastActionWasSwipe =', lastActionWasSwipe);
 
-    // In separate mode with auto-update disabled, commit displayed tracker when user sends a message
-    if (extensionSettings.generationMode === 'separate' && !extensionSettings.autoUpdate) {
+    // In separate/external mode with auto-update disabled, commit displayed tracker when user sends a message
+    if ((extensionSettings.generationMode === 'separate' || extensionSettings.generationMode === 'external') && !extensionSettings.autoUpdate) {
         // Commit whatever is currently displayed in lastGeneratedData
         if (lastGeneratedData.userStats || lastGeneratedData.infoBox || lastGeneratedData.characterThoughts) {
             committedTrackerData.userStats = lastGeneratedData.userStats;
@@ -209,8 +209,8 @@ export async function onMessageReceived(data) {
             // Save to chat metadata
             saveChatData();
         }
-    } else if (extensionSettings.generationMode === 'separate') {
-        // In separate mode, also parse Spotify URLs from the main roleplay response
+    } else if (extensionSettings.generationMode === 'separate' || extensionSettings.generationMode === 'external') {
+        // In separate/external mode, also parse Spotify URLs from the main roleplay response
         const lastMessage = chat[chat.length - 1];
         if (lastMessage && !lastMessage.is_user) {
             const responseText = lastMessage.mes;

--- a/src/systems/ui/layout.js
+++ b/src/systems/ui/layout.js
@@ -385,8 +385,8 @@ export function updateGenerationModeUI() {
         $('#rpg-manual-update').show();
         $('#rpg-external-api-settings').slideDown(200);
         $('#rpg-separate-mode-settings').slideUp(200);
-        // Disable auto-update toggle (not applicable in external mode)
-        $('#rpg-toggle-auto-update').prop('disabled', true);
-        $('#rpg-auto-update-container').css('opacity', '0.5');
+        // Enable auto-update toggle (works in external mode too)
+        $('#rpg-toggle-auto-update').prop('disabled', false);
+        $('#rpg-auto-update-container').css('opacity', '1');
     }
 }


### PR DESCRIPTION
Just fixed the requested bug

## Summary of Changes
Enabled auto-update after messages for external API mode in the rpg-companion extension. The following changes were made:
1. src/systems/integration/sillytavern.js
- Line 92-93: Updated onMessageSent to handle both separate and external modes when committing tracker data with auto-update disabled
- Line 212: Updated onMessageReceived to trigger auto-update for both separate and external modes
2. src/systems/generation/injector.js
- Line 81-85: Updated onGenerationStarted to handle commit logic for both separate and external modes
- Line 249: Updated to inject contextual summary for both separate and external modes
3. src/systems/ui/layout.js
- Lines 383-391: Updated updateGenerationModeUI to enable the auto-update toggle for external mode (changed from disabled to enabled, opacity from 0.5 to 1)