### PR TITLE
Add Reset All Tracker Data button in settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ import {
     setMusicPlayerContainer,
     clearSessionAvatarPrompts
 } from './src/core/state.js';
-import { loadSettings, saveSettings, saveChatData, loadChatData, updateMessageSwipeData } from './src/core/persistence.js';
+import { loadSettings, saveSettings, saveChatData, loadChatData, updateMessageSwipeData, resetAllTrackerData } from './src/core/persistence.js';
 import { registerAllEvents } from './src/core/events.js';
 
 // Generation & Parsing modules
@@ -613,6 +613,30 @@ async function initUI() {
             return;
         }
         await updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory);
+    });
+
+    $('#rpg-reset-tracker-data').on('click', async function() {
+        // Confirm before resetting
+        const confirmed = confirm('Are you sure you want to reset all tracker data for this chat?\n\nThis will clear:\n- Stats, inventory, info box\n- Present characters and thoughts\n- All committed tracker context\n\nThe next Refresh will generate fresh data.');
+        
+        if (!confirmed) {
+            return;
+        }
+
+        // Reset all tracker data
+        resetAllTrackerData();
+        
+        // Clear the UI panels
+        renderUserStats();
+        renderInfoBox();
+        renderThoughts();
+        renderInventory();
+        renderQuests();
+        
+        // Update chat thought overlays
+        updateChatThoughts();
+        
+        toastr.success('All tracker data has been reset. Click "Refresh RPG Info" to generate fresh data.');
     });
 
     $('#rpg-stat-bar-color-low').on('change', function() {

--- a/template.html
+++ b/template.html
@@ -591,6 +591,19 @@
                         Clears all cached data including tracker history and temporary files.
                     </small>
                 </div>
+
+                <!-- Reset Tracker Data Button -->
+                <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--rpg-border);">
+                    <button id="rpg-reset-tracker-data" class="rpg-btn-clear-cache">
+                        <i class="fa-solid fa-rotate-left" aria-hidden="true"></i> <span
+                            data-i18n-key="template.settingsModal.advanced.resetTrackerData">Reset All Tracker Data</span>
+                    </button>
+                    <small style="display: block; margin-top: 8px; color: #888; font-size: 11px;"
+                        data-i18n-key="template.settingsModal.advanced.resetTrackerDataNote">
+                        Clears all tracker data for the current chat (stats, inventory, info box, characters).
+                        The next Refresh will generate fresh data as if starting a new chat.
+                    </small>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds a button in Settings > Advanced to reset all tracker data for the current chat:
- Resets stat values to defaults (100 or 0 for arousal-type stats)
- Clears inventory, quests, info box, and character data
- Preserves user's custom tracker configuration (stat names, enabled states)
- Clears committed context so next Refresh generates fresh data

Useful when users want to start fresh mid-chat without losing their tracker setup.