### PR TITLE
feat: Add preset management system for tracker configurations

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -250,6 +250,18 @@ export let extensionSettings = {
             recentEvents: false // Boolean for recent events widget lock
         },
         characters: {}          // Object mapping character names to their locked fields (e.g., {"Sarah": {relationship: true, thoughts: false}})
+    },
+    // Preset management for tracker configurations
+    presetManager: {
+        // Map of preset ID to preset data (contains name and trackerConfig)
+        presets: {},
+        // Map of character/group entity to preset ID (e.g., "char_0": "preset_123", "group_abc": "preset_456")
+        // Note: This is stored separately and NOT exported with presets
+        characterAssociations: {},
+        // Currently active preset ID
+        activePresetId: null,
+        // Default preset ID (used when no character association exists)
+        defaultPresetId: null
     }
 };
 

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -22,7 +22,7 @@ import {
     updateCommittedTrackerData,
     $musicPlayerContainer
 } from '../../core/state.js';
-import { saveChatData, loadChatData } from '../../core/persistence.js';
+import { saveChatData, loadChatData, autoSwitchPresetForEntity } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
 
 // Generation & Parsing
@@ -296,6 +296,12 @@ export function onCharacterChanged() {
     $('#chat').off('scroll.thoughtPanel');
     $(window).off('resize.thoughtPanel');
     $(document).off('click.thoughtPanel');
+
+    // Auto-switch to the preset associated with this character/group (if any)
+    const presetSwitched = autoSwitchPresetForEntity();
+    // if (presetSwitched) {
+    //     console.log('[RPG Companion] Auto-switched preset for character');
+    // }
 
     // Load chat-specific data when switching chats
     loadChatData();

--- a/style.css
+++ b/style.css
@@ -3933,6 +3933,70 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
    TRACKER EDITOR MODAL
    ============================================ */
 
+/* Preset Management Section */
+.rpg-preset-management {
+    padding: 0.75em 1em;
+    background: var(--rpg-accent);
+    border-bottom: 2px solid var(--rpg-border);
+    margin-bottom: 0;
+}
+
+.rpg-preset-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    flex-wrap: nowrap;
+}
+
+.rpg-preset-row label {
+    font-weight: 600;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+
+.rpg-preset-row .rpg-select {
+    flex: 1;
+    min-width: 120px;
+    max-width: 250px;
+    height: 2.2em;
+    padding: 0 0.6em;
+    font-size: 0.9em;
+}
+
+.rpg-preset-row .rpg-btn-icon {
+    height: 2.2em;
+    width: 2.2em;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9em;
+    flex-shrink: 0;
+}
+
+.rpg-preset-row .rpg-btn-icon.rpg-btn-active {
+    background: var(--rpg-highlight);
+    border-color: var(--rpg-highlight);
+    color: white;
+}
+
+.rpg-preset-association-row {
+    margin-top: 0.5em;
+    padding-top: 0.5em;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.rpg-preset-association-row .checkbox_label {
+    margin: 0;
+    font-size: 0.85em;
+    opacity: 0.9;
+}
+
+.rpg-preset-association-row .checkbox_label strong {
+    color: var(--rpg-highlight);
+    font-weight: 600;
+}
+
 /* Editor tabs */
 .rpg-editor-tabs {
     display: flex;
@@ -9692,4 +9756,104 @@ body[data-theme="cyberpunk"] .rpg-music-widget-play {
 /* Ensure send_form has relative positioning for music widget placement */
 #send_form {
     position: relative !important;
+}
+
+/* ============================================
+   IMPORT MODE DIALOG STYLES
+   ============================================ */
+
+/* Import Mode Dialog Overlay */
+.rpg-import-dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100000;
+}
+
+.rpg-import-dialog {
+    background: var(--SmartThemeBlurTintColor, #2a2a3e);
+    border: 1px solid var(--SmartThemeBorderColor, #4a4a4a);
+    border-radius: 8px;
+    padding: 20px;
+    min-width: 300px;
+    max-width: 400px;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.rpg-import-dialog h4 {
+    margin: 0 0 15px 0;
+    color: var(--SmartThemeBodyColor, #eee);
+}
+
+.rpg-import-dialog h4 i {
+    margin-right: 8px;
+    color: var(--SmartThemeQuoteColor, #e94560);
+}
+
+.rpg-import-dialog p {
+    margin: 0 0 20px 0;
+    color: var(--SmartThemeBodyColor, #ccc);
+    font-size: 0.95em;
+}
+
+.rpg-import-dialog-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.rpg-import-dialog-buttons button {
+    padding: 10px 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.95em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    transition: all 0.2s ease;
+}
+
+.rpg-import-dialog .rpg-btn-secondary {
+    background: var(--black30a, rgba(0, 0, 0, 0.3));
+    border: 1px solid var(--SmartThemeBorderColor, #4a4a4a);
+    color: var(--SmartThemeBodyColor, #ccc);
+}
+
+.rpg-import-dialog .rpg-btn-secondary:hover {
+    background: var(--SmartThemeBorderColor, #4a4a4a);
+    color: white;
+}
+
+.rpg-import-dialog .rpg-btn-primary {
+    background: var(--SmartThemeQuoteColor, #e94560);
+    border: 1px solid var(--SmartThemeQuoteColor, #e94560);
+    color: white;
+}
+
+.rpg-import-dialog .rpg-btn-primary:hover {
+    background: var(--SmartThemeQuoteColor, #ff5a75);
+    border-color: var(--SmartThemeQuoteColor, #ff5a75);
+}
+
+.rpg-import-dialog .rpg-btn-cancel {
+    background: transparent;
+    border: none;
+    color: var(--SmartThemeBodyColor, #888);
+    cursor: pointer;
+    font-size: 0.85em;
+    padding: 5px;
+}
+
+.rpg-import-dialog .rpg-btn-cancel:hover {
+    color: var(--SmartThemeBodyColor, #ccc);
+    text-decoration: underline;
 }

--- a/template.html
+++ b/template.html
@@ -670,6 +670,31 @@
                 aria-label="Close tracker editor">&times;</button>
         </header>
 
+        <!-- Preset Management Section -->
+        <div class="rpg-preset-management">
+            <div class="rpg-preset-row">
+                <label for="rpg-preset-select">Preset:</label>
+                <select id="rpg-preset-select" class="rpg-select">
+                    <!-- Options populated by JavaScript -->
+                </select>
+                <button id="rpg-preset-new" class="rpg-btn-icon" type="button" title="Create New Preset">
+                    <i class="fa-solid fa-plus"></i>
+                </button>
+                <button id="rpg-preset-default" class="rpg-btn-icon" type="button" title="Set as Default Preset">
+                    <i class="fa-solid fa-star"></i>
+                </button>
+                <button id="rpg-preset-delete" class="rpg-btn-icon" type="button" title="Delete Current Preset">
+                    <i class="fa-solid fa-trash"></i>
+                </button>
+            </div>
+            <div class="rpg-preset-association-row">
+                <label class="checkbox_label">
+                    <input type="checkbox" id="rpg-preset-associate">
+                    <span>Use this preset for: <strong id="rpg-preset-entity-name">Character</strong></span>
+                </label>
+            </div>
+        </div>
+
         <!-- Tabs -->
         <div class="rpg-editor-tabs">
             <button class="rpg-editor-tab active" data-tab="userStats">


### PR DESCRIPTION
- Add preset selector dropdown in tracker editor modal
- Support creating, loading, and deleting presets
- Add per-character/group preset associations with auto-switch
- Add default preset functionality with star button
- Update import to offer 'Apply to Current' or 'Create New Preset' options
- Add preset management UI styles and import dialog styles