### PR TITLE
feat(mobile): Add FAB widgets with info display around toggle button

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ import {
     removeMobileTabs,
     setupMobileKeyboardHandling,
     setupContentEditableScrolling,
-    updateMobileTabLabels
+    updateMobileTabLabels,
+    updateFabWidgets
 } from './src/systems/ui/mobile.js';
 import {
     setupDesktopTabs,
@@ -608,6 +609,71 @@ async function initUI() {
         updateDiceDisplay();
     });
 
+    // Mobile FAB Widget toggles - simplified, no position saving (auto-positioned)
+    $('#rpg-toggle-fab-widgets-enabled').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        extensionSettings.mobileFabWidgets.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+        $('#rpg-fab-widget-options').toggle(extensionSettings.mobileFabWidgets.enabled);
+    });
+
+    $('#rpg-toggle-fab-weather-icon').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.weatherIcon) extensionSettings.mobileFabWidgets.weatherIcon = {};
+        extensionSettings.mobileFabWidgets.weatherIcon.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-weather-desc').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.weatherDesc) extensionSettings.mobileFabWidgets.weatherDesc = {};
+        extensionSettings.mobileFabWidgets.weatherDesc.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-clock').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.clock) extensionSettings.mobileFabWidgets.clock = {};
+        extensionSettings.mobileFabWidgets.clock.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-date').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.date) extensionSettings.mobileFabWidgets.date = {};
+        extensionSettings.mobileFabWidgets.date.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-location').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.location) extensionSettings.mobileFabWidgets.location = {};
+        extensionSettings.mobileFabWidgets.location.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-stats').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.stats) extensionSettings.mobileFabWidgets.stats = {};
+        extensionSettings.mobileFabWidgets.stats.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
+    $('#rpg-toggle-fab-attributes').on('change', function() {
+        if (!extensionSettings.mobileFabWidgets) extensionSettings.mobileFabWidgets = {};
+        if (!extensionSettings.mobileFabWidgets.attributes) extensionSettings.mobileFabWidgets.attributes = {};
+        extensionSettings.mobileFabWidgets.attributes.enabled = $(this).prop('checked');
+        saveSettings();
+        updateFabWidgets();
+    });
+
     $('#rpg-manual-update').on('click', async function() {
         if (!extensionSettings.enabled) {
             // console.log('[RPG Companion] Extension is disabled. Please enable it in the Extensions tab.');
@@ -825,6 +891,20 @@ async function initUI() {
     $('#rpg-toggle-auto-avatars-panel').prop('checked', extensionSettings.autoGenerateAvatars || false);
 
     $('#rpg-toggle-dice-display').prop('checked', extensionSettings.showDiceDisplay);
+
+    // Initialize Mobile FAB Widget checkboxes
+    const fabWidgets = extensionSettings.mobileFabWidgets || {};
+    $('#rpg-toggle-fab-widgets-enabled').prop('checked', fabWidgets.enabled || false);
+    $('#rpg-toggle-fab-weather-icon').prop('checked', fabWidgets.weatherIcon?.enabled || false);
+    $('#rpg-toggle-fab-weather-desc').prop('checked', fabWidgets.weatherDesc?.enabled || false);
+    $('#rpg-toggle-fab-clock').prop('checked', fabWidgets.clock?.enabled || false);
+    $('#rpg-toggle-fab-date').prop('checked', fabWidgets.date?.enabled || false);
+    $('#rpg-toggle-fab-location').prop('checked', fabWidgets.location?.enabled || false);
+    $('#rpg-toggle-fab-stats').prop('checked', fabWidgets.stats?.enabled || false);
+    $('#rpg-toggle-fab-attributes').prop('checked', fabWidgets.attributes?.enabled || false);
+    // Toggle visibility of widget options based on master toggle
+    $('#rpg-fab-widget-options').toggle(fabWidgets.enabled || false);
+
     $('#rpg-stat-bar-color-low').val(extensionSettings.statBarColorLow);
     $('#rpg-stat-bar-color-high').val(extensionSettings.statBarColorHigh);
     $('#rpg-theme-select').val(extensionSettings.theme);
@@ -969,6 +1049,8 @@ jQuery(async () => {
         // Load chat-specific data for current chat
         try {
             loadChatData();
+            // Initialize FAB widgets with any loaded data
+            updateFabWidgets();
         } catch (error) {
             console.error('[RPG Companion] Chat data load failed, using defaults:', error);
         }

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -58,6 +58,17 @@ export let extensionSettings = {
         top: 'calc(var(--topBarBlockSize) + 60px)',
         right: '12px'
     }, // Saved position for mobile FAB button
+    // Mobile FAB widget display options (8-position system around the button)
+    mobileFabWidgets: {
+        enabled: false, // Master toggle for FAB widgets
+        weatherIcon: { enabled: false, position: 0 },      // Weather emoji (☀️, 🌧️, etc.)
+        weatherDesc: { enabled: false, position: 1 },      // Weather description text
+        clock: { enabled: false, position: 2 },            // Current time display
+        date: { enabled: false, position: 3 },             // Date display
+        location: { enabled: false, position: 4 },         // Location name
+        stats: { enabled: false, position: 5 },            // All stats as compact numbers
+        attributes: { enabled: false, position: 6 }        // Compact RPG attributes display
+    },
     userStats: JSON.stringify({
         stats: [
             { id: 'health', name: 'Health', value: 100 },

--- a/src/systems/features/classicStats.js
+++ b/src/systems/features/classicStats.js
@@ -8,6 +8,7 @@ import {
     $userStatsContainer
 } from '../../core/state.js';
 import { saveSettings, saveChatData } from '../../core/persistence.js';
+import { updateFabWidgets } from '../ui/mobile.js';
 
 /**
  * Sets up event listeners for classic stat +/- buttons using delegation.
@@ -25,6 +26,7 @@ export function setupClassicStatsButtons() {
             saveChatData();
             // Update only the specific stat value, not the entire stats panel
             $(this).closest('.rpg-classic-stat').find('.rpg-classic-stat-value').text(extensionSettings.classicStats[stat]);
+            updateFabWidgets();
         }
     });
 
@@ -37,6 +39,7 @@ export function setupClassicStatsButtons() {
             saveChatData();
             // Update only the specific stat value, not the entire stats panel
             $(this).closest('.rpg-classic-stat').find('.rpg-classic-stat-value').text(extensionSettings.classicStats[stat]);
+            updateFabWidgets();
         }
     });
 }

--- a/src/systems/generation/apiClient.js
+++ b/src/systems/generation/apiClient.js
@@ -34,6 +34,7 @@ import { renderQuests } from '../rendering/quests.js';
 import { renderMusicPlayer } from '../rendering/musicPlayer.js';
 import { i18n } from '../../core/i18n.js';
 import { generateAvatarsForCharacters } from '../features/avatarGenerator.js';
+import { setFabLoadingState, updateFabWidgets } from '../ui/mobile.js';
 
 // Store the original preset name to restore after tracker generation
 let originalPresetName = null;
@@ -235,6 +236,7 @@ export async function updateRPGData(renderUserStats, renderInfoBox, renderThough
 
     try {
         setIsGenerating(true);
+        setFabLoadingState(true); // Show spinning FAB on mobile
 
         // Update button to show "Updating..." state
         const $updateBtn = $('#rpg-manual-update');
@@ -391,6 +393,8 @@ export async function updateRPGData(renderUserStats, renderInfoBox, renderThough
         }
     } finally {
         setIsGenerating(false);
+        setFabLoadingState(false); // Stop spinning FAB on mobile
+        updateFabWidgets(); // Update FAB widgets with new data
 
         // Restore button to original state
         const $updateBtn = $('#rpg-manual-update');

--- a/src/systems/rendering/infoBox.js
+++ b/src/systems/rendering/infoBox.js
@@ -14,6 +14,7 @@ import { saveChatData } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
 import { isItemLocked } from '../generation/lockManager.js';
 import { repairJSON } from '../../utils/jsonRepair.js';
+import { updateFabWidgets } from '../ui/mobile.js';
 
 /**
  * Helper to generate lock icon HTML if setting is enabled
@@ -615,6 +616,9 @@ export function renderInfoBox() {
         } else {
             updateInfoBoxField(field, value);
         }
+
+        // Update FAB widgets to reflect changes
+        updateFabWidgets();
     });
 
     // Update location size on input as well (real-time)

--- a/src/systems/rendering/userStats.js
+++ b/src/systems/rendering/userStats.js
@@ -20,6 +20,7 @@ import {
 import { getSafeThumbnailUrl } from '../../utils/avatars.js';
 import { buildInventorySummary } from '../generation/promptBuilder.js';
 import { isItemLocked, setItemLock } from '../generation/lockManager.js';
+import { updateFabWidgets } from '../ui/mobile.js';
 
 /**
  * Builds the user stats text string using custom stat names
@@ -424,8 +425,9 @@ export function renderUserStats() {
         saveChatData();
         updateMessageSwipeData();
 
-        // Re-render to update the bar
+        // Re-render to update the bar and FAB widgets
         renderUserStats();
+        updateFabWidgets();
     });
 
     // Add event listeners for mood/conditions editing

--- a/src/systems/ui/trackerEditor.js
+++ b/src/systems/ui/trackerEditor.js
@@ -28,6 +28,7 @@ import {
 import { renderUserStats } from '../rendering/userStats.js';
 import { renderInfoBox } from '../rendering/infoBox.js';
 import { renderThoughts } from '../rendering/thoughts.js';
+import { updateFabWidgets } from './mobile.js';
 
 let $editorModal = null;
 let activeTab = 'userStats';
@@ -258,6 +259,7 @@ function applyTrackerConfig() {
     renderUserStats();
     renderInfoBox();
     renderThoughts();
+    updateFabWidgets(); // Update FAB widgets to reflect new config
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -5154,6 +5154,21 @@ body:has(.rpg-panel.rpg-position-left) #sheld {
     transform: rotate(180deg);
 }
 
+/* FAB Spinning animation during API requests */
+.rpg-mobile-toggle.rpg-fab-loading i {
+    animation: fa-spin 1s infinite linear;
+}
+
+.rpg-mobile-toggle.rpg-fab-loading {
+    box-shadow: 0 0 12px rgba(233, 69, 96, 0.6), 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+/* Hide FAB widgets when panel is open */
+body:has(.rpg-panel.rpg-mobile-open) .rpg-fab-widget-container {
+    opacity: 0;
+    pointer-events: none;
+}
+
 /* Mobile overlay backdrop */
 .rpg-mobile-overlay {
     display: none;
@@ -9857,3 +9872,336 @@ body[data-theme="cyberpunk"] .rpg-music-widget-play {
     color: var(--SmartThemeBodyColor, #ccc);
     text-decoration: underline;
 }
+
+/* ============================================
+   FAB Widget System - Improved Layout
+   ============================================ */
+
+/* Widget container - positioned relative to FAB */
+.rpg-fab-widget-container {
+    position: fixed;
+    pointer-events: none;
+    z-index: 9998;
+}
+
+/* Hide FAB widgets on desktop viewport */
+@media (min-width: 1001px) {
+    .rpg-fab-widget-container {
+        display: none !important;
+    }
+}
+
+/* Individual widget base styling */
+.rpg-fab-widget {
+    position: absolute;
+    pointer-events: auto;
+    background: rgba(20, 20, 35, 0.95);
+    border: 1px solid rgba(100, 150, 255, 0.3);
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-size: 11px;
+    color: #fff;
+    white-space: nowrap;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.5), 0 0 1px rgba(100, 150, 255, 0.3);
+    transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.rpg-fab-widget:hover {
+    border-color: rgba(100, 150, 255, 0.5);
+}
+
+/* Expanded state for truncated widgets - desktop hover and mobile tap */
+.rpg-fab-widget[data-full-text]:hover,
+.rpg-fab-widget[data-full-text].expanded {
+    z-index: 9999 !important;
+    max-width: none !important;
+    white-space: nowrap;
+}
+
+.rpg-fab-widget[data-full-text]:hover .rpg-fab-widget-text,
+.rpg-fab-widget[data-full-text].expanded .rpg-fab-widget-text {
+    /* Show full text on hover/tap */
+}
+
+/* Hide truncated text and show full text on expand */
+.rpg-fab-widget[data-full-text]:hover .rpg-truncated,
+.rpg-fab-widget[data-full-text].expanded .rpg-truncated {
+    display: none;
+}
+
+.rpg-fab-widget[data-full-text]:hover .rpg-full-text,
+.rpg-fab-widget[data-full-text].expanded .rpg-full-text {
+    display: inline;
+}
+
+/* Default: show truncated, hide full */
+.rpg-fab-widget .rpg-full-text {
+    display: none;
+}
+
+.rpg-fab-widget .rpg-truncated {
+    display: inline;
+}
+
+/* 8-Position system - spread out more to avoid overlap
+   Positions: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW */
+
+/* Position 0: North (top center) */
+.rpg-fab-widget-pos-0 {
+    bottom: calc(100% + 15px);
+    left: 50%;
+    transform: translateX(-50%);
+}
+.rpg-fab-widget-pos-0:hover { transform: translateX(-50%) scale(1.05); }
+
+/* Position 1: Northeast */
+.rpg-fab-widget-pos-1 {
+    bottom: calc(100% + 10px);
+    left: calc(100% + 15px);
+}
+
+/* Position 2: East (right center) */
+.rpg-fab-widget-pos-2 {
+    top: 50%;
+    left: calc(100% + 15px);
+    transform: translateY(-50%);
+}
+.rpg-fab-widget-pos-2:hover { transform: translateY(-50%) scale(1.05); }
+
+/* Position 3: Southeast */
+.rpg-fab-widget-pos-3 {
+    top: calc(100% + 10px);
+    left: calc(100% + 15px);
+}
+
+/* Position 4: South (bottom center) */
+.rpg-fab-widget-pos-4 {
+    top: calc(100% + 15px);
+    left: 50%;
+    transform: translateX(-50%);
+}
+.rpg-fab-widget-pos-4:hover { transform: translateX(-50%) scale(1.05); }
+
+/* Position 5: Southwest */
+.rpg-fab-widget-pos-5 {
+    top: calc(100% + 10px);
+    right: calc(100% + 15px);
+    left: auto;
+}
+
+/* Position 6: West - Stats (top edge at FAB center + gap, grows DOWN) */
+.rpg-fab-widget-pos-6 {
+    top: calc(50% + 8px);
+    right: calc(100% + 15px);
+    left: auto;
+}
+
+/* Position 7: Northwest - Attributes (bottom edge at FAB center - gap, grows UP) */
+.rpg-fab-widget-pos-7 {
+    bottom: calc(50% + 8px);
+    right: calc(100% + 15px);
+    left: auto;
+}
+
+/* Centered large widget (when only one is visible) - vertically centered */
+.rpg-fab-widget-centered.rpg-fab-widget-pos-6,
+.rpg-fab-widget-centered.rpg-fab-widget-pos-7 {
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%);
+}
+
+/* Weather icon widget - larger emoji display */
+.rpg-fab-widget-weather-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    padding: 6px;
+    min-width: 32px;
+    min-height: 32px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+/* Weather description widget */
+.rpg-fab-widget-weather-desc {
+    max-width: 100px;
+    font-size: 10px;
+}
+
+/* Clock/Time widget - bottom position with animated clock */
+.rpg-fab-widget-clock {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: 'Roboto Mono', 'Consolas', monospace;
+    font-size: 11px;
+    letter-spacing: 0.5px;
+    padding: 4px 8px;
+    gap: 2px;
+}
+
+/* Mini animated clock face */
+.rpg-fab-clock-face {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    border: 2px solid var(--rpg-border, #4a7ba7);
+    border-radius: 50%;
+    background: var(--rpg-accent, rgba(22, 33, 62, 0.9));
+}
+
+.rpg-fab-clock-hour {
+    position: absolute;
+    width: 2px;
+    height: 7px;
+    background: var(--rpg-text, #eaeaea);
+    left: 50%;
+    bottom: 50%;
+    margin-left: -1px;
+    transform-origin: bottom center;
+    border-radius: 1px;
+}
+
+.rpg-fab-clock-minute {
+    position: absolute;
+    width: 1.5px;
+    height: 9px;
+    background: var(--rpg-highlight, #4a90e2);
+    left: 50%;
+    bottom: 50%;
+    margin-left: -0.75px;
+    transform-origin: bottom center;
+    border-radius: 1px;
+}
+
+.rpg-fab-clock-center {
+    position: absolute;
+    width: 4px;
+    height: 4px;
+    background: var(--rpg-highlight, #4a90e2);
+    border-radius: 50%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.rpg-fab-clock-time {
+    font-size: 11px;
+    white-space: nowrap;
+}
+
+/* Date widget */
+.rpg-fab-widget-date {
+    font-size: 10px;
+}
+
+/* Location widget - two lines */
+.rpg-fab-widget-location {
+    max-width: 90px;
+    font-size: 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Attributes widget - compact grid */
+.rpg-fab-widget-attributes {
+    padding: 6px 10px;
+}
+
+.rpg-fab-widget-attr-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+}
+
+.rpg-fab-widget-attr-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.2;
+}
+
+.rpg-fab-widget-attr-name {
+    font-size: 8px;
+    opacity: 0.7;
+    text-transform: uppercase;
+}
+
+.rpg-fab-widget-attr-value {
+    font-size: 12px;
+    font-weight: bold;
+    color: var(--rpg-highlight, #4a90e2);
+    white-space: nowrap;
+}
+
+/* Stats widget - vertical compact list */
+.rpg-fab-widget-stats {
+    padding: 6px 10px;
+    min-width: 70px;
+    text-align: center;
+}
+
+.rpg-fab-widget-stats-row {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.rpg-fab-widget-stat-item {
+    font-size: 11px;
+    font-family: 'Roboto Mono', 'Consolas', monospace;
+    font-weight: 600;
+    white-space: nowrap;
+    display: block;
+}
+
+/* RPG Attributes widget - 2x3 grid */
+.rpg-fab-widget-attributes {
+    padding: 6px 8px;
+}
+
+.rpg-fab-widget-attr-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2px 10px;
+}
+
+.rpg-fab-widget-attr-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.rpg-fab-widget-attr-name {
+    font-size: 8px;
+    color: rgba(255, 255, 255, 0.6);
+    letter-spacing: 0.5px;
+}
+
+.rpg-fab-widget-attr-value {
+    font-size: 12px;
+    font-weight: 700;
+    color: #6af;
+    font-family: 'Roboto Mono', 'Consolas', monospace;
+}
+
+/* FAB Loading State */
+#rpg-mobile-toggle.rpg-fab-loading {
+    animation: fabSpin 1s linear infinite;
+}
+
+#rpg-mobile-toggle.rpg-fab-loading i {
+    opacity: 0.7;
+}
+
+@keyframes fabSpin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+

--- a/template.html
+++ b/template.html
@@ -395,6 +395,62 @@
 
             </div>
 
+            <!-- Mobile FAB Options Section -->
+            <div class="rpg-settings-group">
+                <h4 data-i18n-key="template.settingsModal.mobileFabTitle"><i class="fa-solid fa-mobile-screen-button"
+                        aria-hidden="true"></i> Mobile Button Widgets</h4>
+                <small class="notes" style="display: block; margin-bottom: 10px;"
+                    data-i18n-key="template.settingsModal.mobileFabNote">
+                    <i class="fa-solid fa-info-circle" aria-hidden="true"></i> Show compact info widgets around the floating button on mobile. Widgets are positioned automatically.
+                </small>
+
+                <label class="checkbox_label">
+                    <input type="checkbox" id="rpg-toggle-fab-widgets-enabled" />
+                    <span data-i18n-key="template.settingsModal.mobileFab.enabled">Enable FAB Widgets</span>
+                </label>
+                <small style="display: block; margin-left: 24px; margin-top: -8px; color: #888; font-size: 11px;"
+                    data-i18n-key="template.settingsModal.mobileFab.enabledNote">
+                    Master toggle to show info widgets around the mobile floating button.
+                </small>
+
+                <div id="rpg-fab-widget-options" style="margin-left: 10px; border-left: 2px solid var(--SmartThemeBorderColor); padding-left: 10px; margin-top: 8px;">
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-weather-icon" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.weatherIcon">Weather Icon</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-weather-desc" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.weatherDesc">Weather Description</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-clock" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.clock">Time/Clock</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-date" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.date">Date</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-location" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.location">Location</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-stats" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.stats">Stats (Health, Energy, etc.)</span>
+                    </label>
+
+                    <label class="checkbox_label">
+                        <input type="checkbox" id="rpg-toggle-fab-attributes" />
+                        <span data-i18n-key="template.settingsModal.mobileFab.attributes">RPG Attributes (STR, DEX, etc.)</span>
+                    </label>
+                </div>
+            </div>
+
             <div class="rpg-settings-group">
                 <h4 data-i18n-key="template.settingsModal.advancedTitle"><i class="fa-solid fa-sliders"
                         aria-hidden="true"></i> Advanced</h4>


### PR DESCRIPTION
- Add 8-position widget system around mobile FAB button (N, NE, E, SE, S, SW, W, NW)
- Display weather icon, weather description, time, date, location around FAB
- Show stats and RPG attributes in larger West/Northwest positions
- Add animated clock face matching main panel design
- Implement expandable text on hover/tap for truncated content
- Add FAB spinner animation during API requests
- Respect tracker preset settings for filtering displayed stats/attributes
- Sync FAB data with lastGeneratedData for real-time updates
- Hide FAB widgets on desktop viewport (>1000px) and when panel is open
- Add settings UI for enabling/disabling individual widget types
- Update FAB widgets on manual edits in tracker editor and stats panels

Examples:
<img width="525" height="355" alt="image" src="https://github.com/user-attachments/assets/503cfbf5-7bca-4953-bfd6-47312944fc63" />