### PR TITLE
fix(presets): defer association changes until Save & Apply

### DIFF
--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -916,6 +916,17 @@ export function hasPresetAssociation() {
 }
 
 /**
+ * Checks if the current character/group is associated with the currently active preset
+ * @returns {boolean} True if the current entity is associated with the active preset
+ */
+export function isAssociatedWithCurrentPreset() {
+    const entityKey = getCurrentEntityKey();
+    const activePresetId = extensionSettings.presetManager?.activePresetId;
+    if (!entityKey || !activePresetId) return false;
+    return extensionSettings.presetManager.characterAssociations[entityKey] === activePresetId;
+}
+
+/**
  * Auto-switches to the preset associated with the current character/group
  * Called when character changes. Falls back to default preset if no association.
  * @returns {boolean} True if a preset was switched, false otherwise


### PR DESCRIPTION
- Add isAssociatedWithCurrentPreset() helper to check if entity is associated with the CURRENT preset (not just any preset)
- Fix checkbox to correctly reflect association with currently selected preset
- Introduce tempAssociation state to track pending association changes
- Only save association changes when clicking Save & Apply, not on preset switch
- Discard pending association changes when clicking X/Cancel
- Auto-update association when switching presets if checkbox was checked
- Improve toast messages to clarify when changes will be applied

Fixes issue where checkbox showed incorrect state and association was saved immediately without waiting for Save & Apply.