### PR TITLE
feat(history): Add 'Send All Enabled Stats on Refresh' option

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -55,7 +55,8 @@ export let extensionSettings = {
         enabled: false, // Master toggle for history persistence feature
         messageCount: 5, // Number of messages to include (0 = all available)
         injectionPosition: 'assistant_message_end', // 'user_message_end', 'assistant_message_end', 'extra_user_message', 'extra_assistant_message'
-        contextPreamble: '' // Optional custom preamble text (empty = use default short one)
+        contextPreamble: '', // Optional custom preamble text (empty = use default short one)
+        sendAllEnabledOnRefresh: false // If true, sends all enabled stats from preset instead of only persistInHistory-enabled stats on Refresh RPG Info
     },
     panelPosition: 'right', // 'left', 'right', or 'top'
     theme: 'default', // Theme: default, sci-fi, fantasy, cyberpunk, custom

--- a/src/systems/ui/trackerEditor.js
+++ b/src/systems/ui/trackerEditor.js
@@ -419,7 +419,8 @@ function resetToDefaults() {
         enabled: false,
         messageCount: 5,
         injectionPosition: 'assistant_message_end',
-        contextPreamble: ''
+        contextPreamble: '',
+        sendAllEnabledOnRefresh: false
     };
 }
 
@@ -1429,11 +1430,13 @@ function renderHistoryPersistenceTab() {
         enabled: false,
         messageCount: 5,
         injectionPosition: 'assistant_message_end',
-        contextPreamble: ''
+        contextPreamble: '',
+        sendAllEnabledOnRefresh: false
     };
     const userStatsConfig = extensionSettings.trackerConfig.userStats;
     const infoBoxConfig = extensionSettings.trackerConfig.infoBox;
     const presentCharsConfig = extensionSettings.trackerConfig.presentCharacters;
+    const generationMode = extensionSettings.generationMode || 'together';
 
     let html = '<div class="rpg-editor-section">';
 
@@ -1446,6 +1449,15 @@ function renderHistoryPersistenceTab() {
     html += `<input type="checkbox" id="rpg-history-persistence-enabled" ${historyPersistence.enabled ? 'checked' : ''}>`;
     html += `<label for="rpg-history-persistence-enabled">Enable History Persistence</label>`;
     html += '</div>';
+
+    // External API Only toggle - only show for separate/external modes
+    if (generationMode === 'separate' || generationMode === 'external') {
+        html += '<div class="rpg-editor-toggle-row" style="margin-top: 8px;">';
+        html += `<input type="checkbox" id="rpg-history-send-all-enabled" ${historyPersistence.sendAllEnabledOnRefresh ? 'checked' : ''}>`;
+        html += `<label for="rpg-history-send-all-enabled">Send All Enabled Stats on Refresh</label>`;
+        html += '</div>';
+        html += `<p class="rpg-editor-hint" style="margin-top: 4px; margin-left: 24px;">When enabled, Refresh RPG Info will include all enabled stats from the preset in history context, ignoring the individual selections below.</p>`;
+    }
 
     // Message count
     html += '<div class="rpg-editor-input-row" style="margin-top: 12px;">';
@@ -1593,13 +1605,19 @@ function setupHistoryPersistenceListeners() {
             enabled: false,
             messageCount: 5,
             injectionPosition: 'assistant_message_end',
-            contextPreamble: ''
+            contextPreamble: '',
+            externalApiOnly: false
         };
     }
 
     // Main toggle
     $('#rpg-history-persistence-enabled').off('change').on('change', function() {
         extensionSettings.historyPersistence.enabled = $(this).is(':checked');
+    });
+
+    // Send All Enabled on Refresh toggle
+    $('#rpg-history-send-all-enabled').off('change').on('change', function() {
+        extensionSettings.historyPersistence.sendAllEnabledOnRefresh = $(this).is(':checked');
     });
 
     // Message count


### PR DESCRIPTION
Adds a new toggle in Edit Trackers -> History Persistence that allows sending all enabled stats from the preset when using Refresh RPG Info, instead of only the individually selected persistInHistory fields.

This helps the separate update AI understand the full context of what has already been tracked and what changes it needs to account for, improving coherence in stat updates without cluttering the main chat history with excessive context data.