### PR TITLE
Fix: Save tracker state per-swipe, per-message

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ import {
     setMusicPlayerContainer,
     clearSessionAvatarPrompts
 } from './src/core/state.js';
-import { loadSettings, saveSettings, saveChatData, loadChatData, updateMessageSwipeData } from './src/core/persistence.js';
+import { loadSettings, saveSettings, saveChatData, loadChatData, updateMessageSwipeData, commitTrackerDataFromPriorMessage } from './src/core/persistence.js';
 import { registerAllEvents } from './src/core/events.js';
 
 // Generation & Parsing modules
@@ -800,6 +800,17 @@ async function initUI() {
             // console.log('[RPG Companion] Extension is disabled. Please enable it in the Extensions tab.');
             return;
         }
+        const currentChat = getContext().chat;
+        let lastAssistantIndex = -1;
+        for (let i = currentChat.length - 1; i >= 0; i--) {
+            if (!currentChat[i].is_user && !currentChat[i].is_system) {
+                lastAssistantIndex = i;
+                break;
+            }
+        }
+        if (lastAssistantIndex !== -1) {
+            commitTrackerDataFromPriorMessage(lastAssistantIndex);
+        }
         await updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory);
     });
 
@@ -807,6 +818,17 @@ async function initUI() {
     $('#rpg-strip-refresh').on('click', async function() {
         if (!extensionSettings.enabled) {
             return;
+        }
+        const currentChat = getContext().chat;
+        let lastAssistantIndex = -1;
+        for (let i = currentChat.length - 1; i >= 0; i--) {
+            if (!currentChat[i].is_user && !currentChat[i].is_system) {
+                lastAssistantIndex = i;
+                break;
+            }
+        }
+        if (lastAssistantIndex !== -1) {
+            commitTrackerDataFromPriorMessage(lastAssistantIndex);
         }
         await updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory);
     });

--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ import {
     onMessageReceived,
     onCharacterChanged,
     onMessageSwiped,
+    onMessageDeleted,
     updatePersonaAvatar,
     clearExtensionPrompts,
     onGenerationEnded,
@@ -1354,6 +1355,7 @@ jQuery(async () => {
                 [event_types.GENERATION_ENDED]: onGenerationEnded,
                 [event_types.CHAT_CHANGED]: [onCharacterChanged, updatePersonaAvatar, restoreCheckpointOnLoad, clearSessionAvatarPrompts],
                 [event_types.MESSAGE_SWIPED]: onMessageSwiped,
+                [event_types.MESSAGE_DELETED]: onMessageDeleted,
                 [event_types.USER_MESSAGE_RENDERED]: updatePersonaAvatar,
                 [event_types.SETTINGS_UPDATED]: updatePersonaAvatar
             });

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -247,16 +247,49 @@ export function updateMessageSwipeData() {
             }
 
             const swipeId = message.swipe_id || 0;
-            message.extra.rpg_companion_swipes[swipeId] = {
+            const swipeEntry = {
                 userStats: lastGeneratedData.userStats,
                 infoBox: lastGeneratedData.infoBox,
                 characterThoughts: lastGeneratedData.characterThoughts
             };
+            message.extra.rpg_companion_swipes[swipeId] = swipeEntry;
+
+            // Mirror to swipe_info so data survives page reloads regardless of active swipe
+            if (message.swipe_info && message.swipe_info[swipeId]) {
+                if (!message.swipe_info[swipeId].extra) {
+                    message.swipe_info[swipeId].extra = {};
+                }
+                if (!message.swipe_info[swipeId].extra.rpg_companion_swipes) {
+                    message.swipe_info[swipeId].extra.rpg_companion_swipes = {};
+                }
+                message.swipe_info[swipeId].extra.rpg_companion_swipes[swipeId] = swipeEntry;
+            }
 
             // console.log('[RPG Companion] Updated message swipe data after user edit');
             break;
         }
     }
+}
+
+/**
+ * Reads RPG tracker data for a specific swipe from a message.
+ * Checks message.extra first (in-memory, current session), then message.swipe_info
+ * (serialized by SillyTavern on save, available after page reload).
+ *
+ * @param {Object} message - The chat message object
+ * @param {number} swipeId - The swipe index to read
+ * @returns {{userStats, infoBox, characterThoughts}|null} The swipe data or null
+ */
+export function getSwipeData(message, swipeId) {
+    // Primary: in-memory extra (current session or after a recent write)
+    const fromExtra = message.extra?.rpg_companion_swipes?.[swipeId];
+    if (fromExtra) return fromExtra;
+
+    // Fallback: swipe_info (populated by ST when loading from disk)
+    const fromSwipeInfo = message.swipe_info?.[swipeId]?.extra?.rpg_companion_swipes?.[swipeId];
+    if (fromSwipeInfo) return fromSwipeInfo;
+
+    return null;
 }
 
 /**

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -225,6 +225,26 @@ export function saveChatData() {
 }
 
 /**
+ * Mirrors a tracker data entry into message.swipe_info so it survives page reloads.
+ * ST only serializes swipe_info to disk; message.extra is in-memory only.
+ * Guard: skips silently if swipe_info[swipeId] doesn't exist yet
+ *
+ * @param {Object} message  - The chat message object
+ * @param {number} swipeId  - The swipe index to mirror into
+ * @param {Object} swipeEntry - { userStats, infoBox, characterThoughts }
+ */
+export function mirrorToSwipeInfo(message, swipeId, swipeEntry) {
+    if (!message.swipe_info || !message.swipe_info[swipeId]) return;
+    if (!message.swipe_info[swipeId].extra) {
+        message.swipe_info[swipeId].extra = {};
+    }
+    if (!message.swipe_info[swipeId].extra.rpg_companion_swipes) {
+        message.swipe_info[swipeId].extra.rpg_companion_swipes = {};
+    }
+    message.swipe_info[swipeId].extra.rpg_companion_swipes[swipeId] = swipeEntry;
+}
+
+/**
  * Updates the last assistant message's swipe data with current tracker data.
  * This ensures user edits are preserved across swipes and included in generation context.
  */
@@ -255,15 +275,7 @@ export function updateMessageSwipeData() {
             message.extra.rpg_companion_swipes[swipeId] = swipeEntry;
 
             // Mirror to swipe_info so data survives page reloads regardless of active swipe
-            if (message.swipe_info && message.swipe_info[swipeId]) {
-                if (!message.swipe_info[swipeId].extra) {
-                    message.swipe_info[swipeId].extra = {};
-                }
-                if (!message.swipe_info[swipeId].extra.rpg_companion_swipes) {
-                    message.swipe_info[swipeId].extra.rpg_companion_swipes = {};
-                }
-                message.swipe_info[swipeId].extra.rpg_companion_swipes[swipeId] = swipeEntry;
-            }
+            mirrorToSwipeInfo(message, swipeId, swipeEntry);
 
             // console.log('[RPG Companion] Updated message swipe data after user edit');
             break;
@@ -290,6 +302,43 @@ export function getSwipeData(message, swipeId) {
     if (fromSwipeInfo) return fromSwipeInfo;
 
     return null;
+}
+
+/**
+ * Commits tracker data from the assistant message immediately before currentMessageIndex.
+ * Walks backward through the chat skipping the current message, user messages, and system
+ * messages until it finds the prior assistant message, then loads its active swipe data.
+ * If no prior assistant message exists or exists without a tracker state, nulls out all fields so
+ * the AI generates from an empty context rather than a ghost state.
+ *
+ * @param {number} currentMessageIndex - Index of the message to start searching before
+ */
+export function commitTrackerDataFromPriorMessage(currentMessageIndex) {
+    const chat = getContext().chat;
+    if (!chat || chat.length === 0) {
+        committedTrackerData.userStats = null;
+        committedTrackerData.infoBox = null;
+        committedTrackerData.characterThoughts = null;
+        return;
+    }
+
+    for (let i = currentMessageIndex - 1; i >= 0; i--) {
+        const message = chat[i];
+        if (message.is_user || message.is_system) continue;
+
+        // Found the prior assistant message — commit its active swipe data
+        const swipeId = message.swipe_id || 0;
+        const swipeData = getSwipeData(message, swipeId);
+        committedTrackerData.userStats = swipeData?.userStats || null;
+        committedTrackerData.infoBox = swipeData?.infoBox || null;
+        committedTrackerData.characterThoughts = swipeData?.characterThoughts || null;
+        return;
+    }
+
+    // No prior assistant message found — use empty context
+    committedTrackerData.userStats = null;
+    committedTrackerData.infoBox = null;
+    committedTrackerData.characterThoughts = null;
 }
 
 /**

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -342,6 +342,56 @@ export function commitTrackerDataFromPriorMessage(currentMessageIndex) {
 }
 
 /**
+ * Populates a message's current swipe slot with tracker data inherited from the
+ * nearest prior assistant message, when no tracker data has been generated for
+ * this swipe yet (e.g. auto-update is disabled).
+ *
+ * This ensures that commitTrackerDataFromPriorMessage can always find a tracker
+ * state to commit when the user sends the next message, rather than nulling
+ * everything out and resetting the tracker display to empty.
+ *
+ * Does nothing if the current swipe already has its own tracker data.
+ *
+ * @param {Object} message - The assistant message object to inherit into
+ * @param {number} messageIndex - Index of that message in chat
+ * @returns {boolean} True if inheritance was written, false otherwise
+ */
+export function inheritSwipeDataFromPriorMessage(message, messageIndex) {
+    const chat = getContext().chat;
+    if (!chat) return false;
+
+    const currentSwipeId = message.swipe_id || 0;
+
+    // Don't overwrite if this swipe already has its own tracker data.
+    if (getSwipeData(message, currentSwipeId)) return false;
+
+    // Walk backward to find the nearest prior assistant message with swipe data.
+    for (let i = messageIndex - 1; i >= 0; i--) {
+        const msg = chat[i];
+        if (msg.is_user || msg.is_system) continue;
+
+        const swipeId = msg.swipe_id || 0;
+        const swipeData = getSwipeData(msg, swipeId);
+        if (!swipeData) return false; // Prior assistant also has no data — nothing to inherit
+
+        // Write inherited data into this swipe slot.
+        if (!message.extra) message.extra = {};
+        if (!message.extra.rpg_companion_swipes) message.extra.rpg_companion_swipes = {};
+
+        const inherited = {
+            userStats: swipeData.userStats,
+            infoBox: swipeData.infoBox,
+            characterThoughts: swipeData.characterThoughts
+        };
+        message.extra.rpg_companion_swipes[currentSwipeId] = inherited;
+        mirrorToSwipeInfo(message, currentSwipeId, inherited);
+        // console.log('[RPG Companion] Inherited tracker data from chat[' + i + '] into current swipe slot', currentSwipeId);
+        return true;
+    }
+    return false;
+}
+
+/**
  * Loads RPG data from the current chat's metadata.
  * Automatically migrates v1 inventory to v2 format if needed.
  */

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -322,6 +322,8 @@ export function commitTrackerDataFromPriorMessage(currentMessageIndex) {
         return;
     }
 
+    // console.log('[RPG Companion] commitTrackerDataFromPriorMessage called with index', currentMessageIndex, '| chat.length =', chat.length);
+
     for (let i = currentMessageIndex - 1; i >= 0; i--) {
         const message = chat[i];
         if (message.is_user || message.is_system) continue;
@@ -329,6 +331,7 @@ export function commitTrackerDataFromPriorMessage(currentMessageIndex) {
         // Found the prior assistant message — commit its active swipe data
         const swipeId = message.swipe_id || 0;
         const swipeData = getSwipeData(message, swipeId);
+        // console.log('[RPG Companion] Committing from chat[' + i + '] swipe', swipeId, '| has swipe data:', !!swipeData);
         committedTrackerData.userStats = swipeData?.userStats || null;
         committedTrackerData.infoBox = swipeData?.infoBox || null;
         const rawCharacterThoughts = swipeData?.characterThoughts;

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -331,7 +331,13 @@ export function commitTrackerDataFromPriorMessage(currentMessageIndex) {
         const swipeData = getSwipeData(message, swipeId);
         committedTrackerData.userStats = swipeData?.userStats || null;
         committedTrackerData.infoBox = swipeData?.infoBox || null;
-        committedTrackerData.characterThoughts = swipeData?.characterThoughts || null;
+        const rawCharacterThoughts = swipeData?.characterThoughts;
+        committedTrackerData.characterThoughts =
+            rawCharacterThoughts == null
+                ? null
+                : (typeof rawCharacterThoughts === 'string'
+                    ? rawCharacterThoughts
+                    : JSON.stringify(rawCharacterThoughts));
         return;
     }
 

--- a/src/core/persistence.js
+++ b/src/core/persistence.js
@@ -372,7 +372,7 @@ export function inheritSwipeDataFromPriorMessage(message, messageIndex) {
 
         const swipeId = msg.swipe_id || 0;
         const swipeData = getSwipeData(msg, swipeId);
-        if (!swipeData) return false; // Prior assistant also has no data — nothing to inherit
+        if (!swipeData) continue; // No data on this assistant message; keep searching further back
 
         // Write inherited data into this swipe slot.
         if (!message.extra) message.extra = {};

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -382,6 +382,32 @@ export let isPlotProgression = false;
 export let isAwaitingNewMessage = false;
 
 /**
+ * Monotonically-increasing counter used to detect stale separate-mode tracker
+ * generation results. Incremented each time a new automated generation is
+ * triggered or a message deletion occurs so any in-flight (or pending) call
+ * from a previous generation can recognise that its result is no longer valid.
+ */
+let separateGenerationId = 0;
+
+/**
+ * Returns the current separate generation ID.
+ * @returns {number}
+ */
+export function getSeparateGenerationId() {
+    return separateGenerationId;
+}
+
+/**
+ * Increments and returns the new separate generation ID.
+ * Call this when starting a new generation or when a deletion
+ * invalidates any pending/in-flight generation.
+ * @returns {number} The new ID
+ */
+export function incrementSeparateGenerationId() {
+    return ++separateGenerationId;
+}
+
+/**
  * Temporary storage for pending dice roll (not saved until user clicks "Save Roll")
  */
 export let pendingDiceRoll = null;

--- a/src/systems/generation/apiClient.js
+++ b/src/systems/generation/apiClient.js
@@ -20,7 +20,7 @@ import {
     setLastActionWasSwipe,
     $musicPlayerContainer
 } from '../../core/state.js';
-import { saveChatData } from '../../core/persistence.js';
+import { saveChatData, mirrorToSwipeInfo } from '../../core/persistence.js';
 import {
     generateSeparateUpdatePrompt
 } from './promptBuilder.js';
@@ -317,11 +317,15 @@ export async function updateRPGData(renderUserStats, renderInfoBox, renderThough
                 }
 
                 const currentSwipeId = lastMessage.swipe_id || 0;
-                lastMessage.extra.rpg_companion_swipes[currentSwipeId] = {
+                const swipeEntry = {
                     userStats: parsedData.userStats,
                     infoBox: parsedData.infoBox,
                     characterThoughts: parsedData.characterThoughts
                 };
+                lastMessage.extra.rpg_companion_swipes[currentSwipeId] = swipeEntry;
+
+                // Mirror to swipe_info so this swipe survives page reload even if never manually edited
+                mirrorToSwipeInfo(lastMessage, currentSwipeId, swipeEntry);
 
                 // console.log('[RPG Companion] Stored separate mode RPG data for message swipe', currentSwipeId);
             }

--- a/src/systems/generation/apiClient.js
+++ b/src/systems/generation/apiClient.js
@@ -18,7 +18,8 @@ import {
     lastActionWasSwipe,
     setIsGenerating,
     setLastActionWasSwipe,
-    $musicPlayerContainer
+    $musicPlayerContainer,
+    getSeparateGenerationId
 } from '../../core/state.js';
 import { saveChatData, mirrorToSwipeInfo } from '../../core/persistence.js';
 import {
@@ -218,7 +219,7 @@ export async function switchToPreset(presetName) {
  * @param {Function} renderThoughts - UI function to render character thoughts
  * @param {Function} renderInventory - UI function to render inventory
  */
-export async function updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory) {
+export async function updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory, generationId = null) {
     if (isGenerating) {
         // console.log('[RPG Companion] Already generating, skipping...');
         return;
@@ -260,6 +261,14 @@ export async function updateRPGData(renderUserStats, renderInfoBox, renderThough
                 prompt: prompt,
                 quietToLoud: false
             });
+        }
+
+        // If a generationId was provided and the counter has since been incremented
+        // (by a deletion or a newer generation), discard this result entirely.
+        // The finally block still runs to restore button state.
+        if (generationId !== null && getSeparateGenerationId() !== generationId) {
+            // console.log('[RPG Companion] ⚠️ Separate generation result discarded — superseded (genId', generationId, '!= current', getSeparateGenerationId(), ')');
+            return;
         }
 
         if (response) {

--- a/src/systems/generation/injector.js
+++ b/src/systems/generation/injector.js
@@ -30,6 +30,7 @@ import {
     SPOTIFY_FORMAT_INSTRUCTION
 } from './promptBuilder.js';
 import { restoreCheckpointOnLoad } from '../features/chapterCheckpoint.js';
+import { commitTrackerDataFromPriorMessage } from '../../core/persistence.js';
 
 // Track suppression state for event handler
 let currentSuppressionState = false;
@@ -622,25 +623,15 @@ export async function onGenerationStarted(type, data, dryRun) {
         const shouldCommit = isUserMessage && !lastActionWasSwipe && currentChatLength !== lastCommittedChatLength;
 
         if (shouldCommit) {
-            // console.log('[RPG Companion] 📝 TOGETHER MODE COMMIT: User sent message - committing data from BEFORE user message');
+            // console.log('[RPG Companion] 📝 TOGETHER MODE COMMIT: User sent message - committing from N-1 assistant message');
             // console.log('[RPG Companion]   Chat length:', currentChatLength, 'Last committed:', lastCommittedChatLength);
-            // console.log('[RPG Companion]   BEFORE: committedTrackerData =', {
-            //     userStats: committedTrackerData.userStats ? `${committedTrackerData.userStats.substring(0, 50)}...` : 'null',
-            //     infoBox: committedTrackerData.infoBox ? 'exists' : 'null',
-            //     characterThoughts: committedTrackerData.characterThoughts ? `${committedTrackerData.characterThoughts.substring(0, 100)}...` : 'null'
-            // // });
-            // console.log('[RPG Companion]   BEFORE: lastGeneratedData =', {
-            //     userStats: lastGeneratedData.userStats ? `${lastGeneratedData.userStats.substring(0, 50)}...` : 'null',
-            //     infoBox: lastGeneratedData.infoBox ? 'exists' : 'null',
-            //     characterThoughts: lastGeneratedData.characterThoughts ? `${lastGeneratedData.characterThoughts.substring(0, 100)}...` : 'null'
-            // });
 
-            // Commit displayed data (from before user sent message)
-            committedTrackerData.userStats = lastGeneratedData.userStats;
-            committedTrackerData.infoBox = lastGeneratedData.infoBox;
-            committedTrackerData.characterThoughts = lastGeneratedData.characterThoughts;
+            // Commit from the prior assistant message's swipe store (N-1 rule).
+            // currentChatLength - 1 is the new AI placeholder; the function walks backward
+            // past it and the user message to find the previous AI message's tracker state.
+            commitTrackerDataFromPriorMessage(currentChatLength - 1);
 
-            // Track chat length to prevent duplicate commits
+            // Track chat length to prevent duplicate commits from streaming
             lastCommittedChatLength = currentChatLength;
 
             // console.log('[RPG Companion]   AFTER: committedTrackerData =', {
@@ -668,38 +659,14 @@ export async function onGenerationStarted(type, data, dryRun) {
     // console.log('[RPG Companion DEBUG] Before generating:', lastGeneratedData.characterThoughts, ' , committed - ', committedTrackerData.characterThoughts);
     if ((extensionSettings.generationMode === 'separate' || extensionSettings.generationMode === 'external') && !isGenerating) {
         if (!lastActionWasSwipe) {
-            // User sent a new message - commit lastGeneratedData before generation
-            // console.log('[RPG Companion] 📝 COMMIT: New message - committing lastGeneratedData');
-            // console.log('[RPG Companion]   BEFORE commit - committedTrackerData:', {
-            //      userStats: committedTrackerData.userStats ? 'exists' : 'null',
-            //      infoBox: committedTrackerData.infoBox ? 'exists' : 'null',
-            //      characterThoughts: committedTrackerData.characterThoughts ? 'exists' : 'null'
-            // // });
-            // console.log('[RPG Companion]   BEFORE commit - lastGeneratedData:', {
-            //      userStats: lastGeneratedData.userStats ? 'exists' : 'null',
-            //      infoBox: lastGeneratedData.infoBox ? 'exists' : 'null',
-            //      characterThoughts: lastGeneratedData.characterThoughts ? 'exists' : 'null'
-            // });
-            committedTrackerData.userStats = lastGeneratedData.userStats;
-            committedTrackerData.infoBox = lastGeneratedData.infoBox;
-            committedTrackerData.characterThoughts = lastGeneratedData.characterThoughts;
-            // console.log('[RPG Companion]   AFTER commit - committedTrackerData:', {
-            //      userStats: committedTrackerData.userStats ? 'exists' : 'null',
-            //      infoBox: committedTrackerData.infoBox ? 'exists' : 'null',
-            //      characterThoughts: committedTrackerData.characterThoughts ? 'exists' : 'null'
-            // });
-
-            // Reset flag after committing (ready for next cycle)
-
-        } else {
-            // console.log('[RPG Companion] 🔄 SWIPE: Using existing committedTrackerData (no commit)');
-            // console.log('[RPG Companion]   committedTrackerData:', {
-            //      userStats: committedTrackerData.userStats ? 'exists' : 'null',
-            //      infoBox: committedTrackerData.infoBox ? 'exists' : 'null',
-            //      characterThoughts: committedTrackerData.characterThoughts ? 'exists' : 'null'
-            // });
-            // Reset flag after using it (swipe generation complete, ready for next action)
+            // User sent a new message - commit from the prior assistant message's swipe store
+            // (N-1 rule) rather than lastGeneratedData, which may reflect a sibling swipe's
+            // outcome and would poison the context for the new generation.
+            // currentChatLength - 1 is the new AI placeholder; search starts before it.
+            commitTrackerDataFromPriorMessage(currentChatLength - 1);
         }
+        // If lastActionWasSwipe, context was already committed by commitTrackerDataFromPriorMessage
+        // in onMessageSwiped before generation started.
     }
 
     // Use the committed tracker data as source for generation

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -22,7 +22,7 @@ import {
     updateCommittedTrackerData,
     $musicPlayerContainer
 } from '../../core/state.js';
-import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData } from '../../core/persistence.js';
+import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData, commitTrackerDataFromPriorMessage, mirrorToSwipeInfo } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
 
 // Generation & Parsing
@@ -118,15 +118,12 @@ export function onMessageSent() {
     // The RPG data comes embedded in the main response
     // FAB spinning is handled by apiClient.js for separate/external modes when updateRPGData() is called
 
-    // For separate mode with auto-update disabled, commit displayed tracker
+    // For separate mode with auto-update disabled, commit from the prior assistant message's
+    // swipe store rather than lastGeneratedData to avoid ghost context from sibling swipes.
+    // At this point chat[chat.length - 1] is the user message, so search from before it.
     if (extensionSettings.generationMode === 'separate' && !extensionSettings.autoUpdate) {
-        if (lastGeneratedData.userStats || lastGeneratedData.infoBox || lastGeneratedData.characterThoughts) {
-            committedTrackerData.userStats = lastGeneratedData.userStats;
-            committedTrackerData.infoBox = lastGeneratedData.infoBox;
-            committedTrackerData.characterThoughts = lastGeneratedData.characterThoughts;
-
-            // console.log('[RPG Companion] 💾 SEPARATE MODE: Committed displayed tracker (auto-update disabled)');
-        }
+        commitTrackerDataFromPriorMessage(chat.length - 1);
+        // console.log('[RPG Companion] 💾 SEPARATE MODE: Committed from prior assistant message (auto-update disabled)');
     }
 }
 
@@ -192,11 +189,15 @@ export async function onMessageReceived(data) {
             }
 
             const currentSwipeId = lastMessage.swipe_id || 0;
-            lastMessage.extra.rpg_companion_swipes[currentSwipeId] = {
+            const swipeEntry = {
                 userStats: parsedData.userStats,
                 infoBox: parsedData.infoBox,
                 characterThoughts: parsedData.characterThoughts
             };
+            lastMessage.extra.rpg_companion_swipes[currentSwipeId] = swipeEntry;
+
+            // Mirror to swipe_info so this swipe survives page reload even if never manually edited
+            mirrorToSwipeInfo(lastMessage, currentSwipeId, swipeEntry);
 
             // console.log('[RPG Companion] Stored RPG data for swipe', currentSwipeId);
 
@@ -377,6 +378,9 @@ export function onMessageSwiped(messageIndex) {
         // This is a NEW swipe that will trigger generation
         setLastActionWasSwipe(true);
         setIsAwaitingNewMessage(true);
+        // Immediately commit context from the prior assistant message (N-1) so generation
+        // uses the world state before this message, not the last-viewed sibling swipe.
+        commitTrackerDataFromPriorMessage(messageIndex);
         // console.log('[RPG Companion] 🔵 NEW swipe detected - Set lastActionWasSwipe = true');
     } else {
         // This is navigating to an EXISTING swipe - don't change the flag

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -20,7 +20,9 @@ import {
     setIsAwaitingNewMessage,
     updateLastGeneratedData,
     updateCommittedTrackerData,
-    $musicPlayerContainer
+    $musicPlayerContainer,
+    getSeparateGenerationId,
+    incrementSeparateGenerationId
 } from '../../core/state.js';
 import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData, commitTrackerDataFromPriorMessage, mirrorToSwipeInfo } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
@@ -266,8 +268,13 @@ export async function onMessageReceived(data) {
         // Trigger auto-update if enabled (for both separate and external modes)
         // Only trigger if this is a newly generated message, not loading chat history
         if (extensionSettings.autoUpdate && isAwaitingNewMessage) {
+            // Capture the current generation ID before the async gap so that any
+            // message deletion (or a newer generation) that increments the counter
+            // while the 500ms timer or the API call is in-flight will cause
+            // updateRPGData to discard its result rather than stomping the UI.
+            const genId = incrementSeparateGenerationId();
             setTimeout(async () => {
-                await updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory);
+                await updateRPGData(renderUserStats, renderInfoBox, renderThoughts, renderInventory, genId);
                 // Update FAB widgets and strip widgets after separate/external mode update completes
                 setFabLoadingState(false);
                 updateFabWidgets();
@@ -438,6 +445,10 @@ export function onMessageDeleted() {
     if (!extensionSettings.enabled) return;
 
     // console.log('[RPG Companion] 🗑️ EVENT: onMessageDeleted');
+
+    // Invalidate any pending or in-flight separate-mode generation so
+    // its result is not applied to the (now-changed) chat tail.
+    incrementSeparateGenerationId();
 
     const currentChat = getContext().chat;
 

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -74,7 +74,7 @@ function syncLastGeneratedDataFromSwipeStore(currentChat) {
             if (swipeData) {
                 lastGeneratedData.userStats = swipeData.userStats || null;
                 lastGeneratedData.infoBox = swipeData.infoBox || null;
-                // Normalise characterThoughts to string (backward compat with old object format).
+                // Normalize characterThoughts to string (backward compat with old object format).
                 if (swipeData.characterThoughts && typeof swipeData.characterThoughts === 'object') {
                     lastGeneratedData.characterThoughts = JSON.stringify(swipeData.characterThoughts, null, 2);
                 } else {

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -22,7 +22,7 @@ import {
     updateCommittedTrackerData,
     $musicPlayerContainer
 } from '../../core/state.js';
-import { saveChatData, loadChatData, autoSwitchPresetForEntity } from '../../core/persistence.js';
+import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
 
 // Generation & Parsing
@@ -67,20 +67,19 @@ export function commitTrackerData() {
         const message = chat[i];
         if (!message.is_user) {
             // Found last assistant message - commit its tracker data
-            if (message.extra && message.extra.rpg_companion_swipes) {
-                const swipeId = message.swipe_id || 0;
-                const swipeData = message.extra.rpg_companion_swipes[swipeId];
+            const swipeId = message.swipe_id || 0;
+            const swipeData = getSwipeData(message, swipeId);
 
-                if (swipeData) {
-                    // console.log('[RPG Companion] Committing tracker data from assistant message at index', i, 'swipe', swipeId);
-                    committedTrackerData.userStats = swipeData.userStats || null;
-                    committedTrackerData.infoBox = swipeData.infoBox || null;
-                    committedTrackerData.characterThoughts = swipeData.characterThoughts || null;
-                } else {
-                    // console.log('[RPG Companion] No swipe data found for swipe', swipeId);
-                }
+            if (swipeData) {
+                // console.log('[RPG Companion] Committing tracker data from assistant message at index', i, 'swipe', swipeId);
+                committedTrackerData.userStats = swipeData.userStats || null;
+                committedTrackerData.infoBox = swipeData.infoBox || null;
+                committedTrackerData.characterThoughts = swipeData.characterThoughts || null;
             } else {
-                // console.log('[RPG Companion] No RPG data found in last assistant message');
+                // No saved swipe data — treat as empty (e.g. first message, no prior generation)
+                committedTrackerData.userStats = null;
+                committedTrackerData.infoBox = null;
+                committedTrackerData.characterThoughts = null;
             }
             break;
         }
@@ -386,12 +385,12 @@ export function onMessageSwiped(messageIndex) {
 
     // console.log('[RPG Companion] Loading data for swipe', currentSwipeId);
 
-    // IMPORTANT: onMessageSwiped is for DISPLAY only!
-    // lastGeneratedData is for DISPLAY, committedTrackerData is for GENERATION
-    // It's safe to load swipe data into lastGeneratedData - it won't be committed due to !lastActionWasSwipe check
-    if (message.extra && message.extra.rpg_companion_swipes && message.extra.rpg_companion_swipes[currentSwipeId]) {
-        const swipeData = message.extra.rpg_companion_swipes[currentSwipeId];
-
+    // Load saved swipe data into both display (lastGeneratedData) and extensionSettings.
+    // Safe to call parseUserStats() unconditionally because updateMessageSwipeData() is called
+    // on every manual edit, so the swipe store always reflects the latest user changes before
+    // any navigation can overwrite them.
+    const swipeData = getSwipeData(message, currentSwipeId);
+    if (swipeData) {
         // Load swipe data into lastGeneratedData for display (both modes)
         lastGeneratedData.userStats = swipeData.userStats || null;
         lastGeneratedData.infoBox = swipeData.infoBox || null;
@@ -403,13 +402,12 @@ export function onMessageSwiped(messageIndex) {
             lastGeneratedData.characterThoughts = swipeData.characterThoughts || null;
         }
 
-        // DON'T parse user stats when loading swipe data
-        // This would overwrite manually edited fields (like Conditions) with old swipe data
-        // The lastGeneratedData is loaded for display purposes only
-        // parseUserStats() updates extensionSettings.userStats which should only be modified
-        // by new generations or manual edits, not by swipe navigation
+        // Sync extensionSettings.userStats so stat bars reflect this swipe
+        if (swipeData.userStats) {
+            parseUserStats(swipeData.userStats);
+        }
 
-        // console.log('[RPG Companion] 🔄 Loaded swipe data into lastGeneratedData for display:', currentSwipeId);
+        // console.log('[RPG Companion] 🔄 Loaded swipe data for swipe:', currentSwipeId);
     } else {
         // console.log('[RPG Companion] ℹ️ No stored data for swipe:', currentSwipeId);
     }

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -486,6 +486,10 @@ export function onMessageSwiped(messageIndex) {
     renderQuests();
     renderMusicPlayer($musicPlayerContainer[0]);
 
+    // Update widget strips with the newly loaded swipe data
+    updateFabWidgets();
+    updateStripWidgets();
+
     // Update chat thought overlays
     updateChatThoughts();
 }

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -303,8 +303,9 @@ export async function onMessageReceived(data) {
 
             // When auto-update is disabled, no tracker API call will run for this message. 
             // Inherit the prior assistant message's tracker data into this swipe slot so that 
-            // commitTrackerDataFromPriorMessage can find a valid state next turn instead of nulling everything
-            if (!extensionSettings.autoUpdate && isAwaitingNewMessage) {
+            // commitTrackerDataFromPriorMessage can find a valid state next turn instead of nulling everything.
+            // Inheritance does not overwrite existing data, so it's safe to call even if the condition misses an edge case.
+            if (!extensionSettings.autoUpdate || !isAwaitingNewMessage) {
                 inheritSwipeDataFromPriorMessage(lastMessage, chat.length - 1);
             }
         }

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -306,7 +306,7 @@ export async function onMessageReceived(data) {
             // When auto-update is disabled,no tracker API call will run for this message. 
             // Inherit the prior assistant message's tracker data into this swipe slot so that 
             // commitTrackerDataFromPriorMessage can find a valid state next turn instead of nulling everything
-            if (!extensionSettings.autoUpdate || !isAwaitingNewMessage) {
+            if (!extensionSettings.autoUpdate && isAwaitingNewMessage) {
                 inheritSwipeDataFromPriorMessage(lastMessage, chat.length - 1);
             }
         }

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -429,6 +429,88 @@ export function onMessageSwiped(messageIndex) {
 }
 
 /**
+ * Event handler for when a message is deleted.
+ * Re-syncs lastGeneratedData, committedTrackerData, and all UI panels to the
+ * new last assistant message's active swipe — or clears everything if no
+ * assistant messages remain.
+ */
+export function onMessageDeleted() {
+    if (!extensionSettings.enabled) return;
+
+    // console.log('[RPG Companion] 🗑️ EVENT: onMessageDeleted');
+
+    const currentChat = getContext().chat;
+
+    // Walk backward to find the new last assistant message.
+    let lastAssistantIndex = -1;
+    for (let i = currentChat.length - 1; i >= 0; i--) {
+        if (!currentChat[i].is_user && !currentChat[i].is_system) {
+            lastAssistantIndex = i;
+            break;
+        }
+    }
+
+    if (lastAssistantIndex === -1) {
+        // No assistant messages remain — clear all state.
+        lastGeneratedData.userStats = null;
+        lastGeneratedData.infoBox = null;
+        lastGeneratedData.characterThoughts = null;
+        committedTrackerData.userStats = null;
+        committedTrackerData.infoBox = null;
+        committedTrackerData.characterThoughts = null;
+        // console.log('[RPG Companion] 🗑️ No assistant messages remain — cleared all tracker state.');
+    } else {
+        const message = currentChat[lastAssistantIndex];
+        const swipeId = message.swipe_id || 0;
+        const swipeData = getSwipeData(message, swipeId);
+
+        if (swipeData) {
+            // Restore display state from the new tail message's active swipe.
+            lastGeneratedData.userStats = swipeData.userStats || null;
+            lastGeneratedData.infoBox = swipeData.infoBox || null;
+            // Normalise characterThoughts to string (backward compat with old object format).
+            if (swipeData.characterThoughts && typeof swipeData.characterThoughts === 'object') {
+                lastGeneratedData.characterThoughts = JSON.stringify(swipeData.characterThoughts, null, 2);
+            } else {
+                lastGeneratedData.characterThoughts = swipeData.characterThoughts || null;
+            }
+
+            // Sync stat bars.
+            if (swipeData.userStats) {
+                parseUserStats(swipeData.userStats);
+            }
+
+            // console.log('[RPG Companion] 🗑️ Restored display state from assistant message at index', lastAssistantIndex, 'swipe', swipeId);
+        } else {
+            // No swipe data for this message — clear display state.
+            lastGeneratedData.userStats = null;
+            lastGeneratedData.infoBox = null;
+            lastGeneratedData.characterThoughts = null;
+            // console.log('[RPG Companion] 🗑️ No swipe data for last assistant message — cleared display state.');
+        }
+
+        // Commit context from the message *before* the new tail assistant message,
+        // so any subsequent generation uses the correct N-1 world state.
+        commitTrackerDataFromPriorMessage(lastAssistantIndex);
+    }
+
+    // Re-render all panels.
+    renderUserStats();
+    renderInfoBox();
+    renderThoughts();
+    renderInventory();
+    renderQuests();
+    renderMusicPlayer($musicPlayerContainer[0]);
+
+    // Update widget strips.
+    updateFabWidgets();
+    updateStripWidgets();
+
+    // Persist updated state.
+    saveChatData();
+}
+
+/**
  * Update the persona avatar image when user switches personas
  */
 export function updatePersonaAvatar() {

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -114,7 +114,14 @@ export function commitTrackerData() {
                 // console.log('[RPG Companion] Committing tracker data from assistant message at index', i, 'swipe', swipeId);
                 committedTrackerData.userStats = swipeData.userStats || null;
                 committedTrackerData.infoBox = swipeData.infoBox || null;
-                committedTrackerData.characterThoughts = swipeData.characterThoughts || null;
+                const rawCharacterThoughts = swipeData.characterThoughts;
+                if (rawCharacterThoughts == null) {
+                    committedTrackerData.characterThoughts = null;
+                } else if (typeof rawCharacterThoughts === 'object') {
+                    committedTrackerData.characterThoughts = JSON.stringify(rawCharacterThoughts);
+                } else {
+                    committedTrackerData.characterThoughts = String(rawCharacterThoughts);
+                }
             } else {
                 // No saved swipe data — treat as empty (e.g. first message, no prior generation)
                 committedTrackerData.userStats = null;

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -105,7 +105,7 @@ export function commitTrackerData() {
     // Find the last assistant message
     for (let i = chat.length - 1; i >= 0; i--) {
         const message = chat[i];
-        if (!message.is_user) {
+        if (!message.is_user && !message.is_system) {
             // Found last assistant message - commit its tracker data
             const swipeId = message.swipe_id || 0;
             const swipeData = getSwipeData(message, swipeId);

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -54,6 +54,45 @@ import { updateAllCheckpointIndicators } from '../ui/checkpointUI.js';
 import { restoreCheckpointOnLoad } from '../features/chapterCheckpoint.js';
 
 /**
+ * Reads the swipe store of the last assistant message in `currentChat` and
+ * writes its data into `lastGeneratedData`, including syncing stat bars via
+ * `parseUserStats`.  If no assistant message exists, or none has stored swipe
+ * data, `lastGeneratedData` is left unchanged.
+ *
+ * Use this wherever the displayed tracker state must be re-derived from the
+ * authoritative swipe store rather than from chat_metadata (e.g. after a
+ * CHAT_CHANGED caused by branching, or after a message deletion).
+ *
+ * @param {Array} currentChat - Live chat array from getContext().chat
+ * @returns {boolean} True if swipe data was found and applied
+ */
+function syncLastGeneratedDataFromSwipeStore(currentChat) {
+    for (let i = currentChat.length - 1; i >= 0; i--) {
+        const msg = currentChat[i];
+        if (!msg.is_user && !msg.is_system) {
+            const swipeId = msg.swipe_id || 0;
+            const swipeData = getSwipeData(msg, swipeId);
+            if (swipeData) {
+                lastGeneratedData.userStats = swipeData.userStats || null;
+                lastGeneratedData.infoBox = swipeData.infoBox || null;
+                // Normalise characterThoughts to string (backward compat with old object format).
+                if (swipeData.characterThoughts && typeof swipeData.characterThoughts === 'object') {
+                    lastGeneratedData.characterThoughts = JSON.stringify(swipeData.characterThoughts, null, 2);
+                } else {
+                    lastGeneratedData.characterThoughts = swipeData.characterThoughts || null;
+                }
+                if (swipeData.userStats) {
+                    parseUserStats(swipeData.userStats);
+                }
+                return true;
+            }
+            return false; // Last assistant message exists but has no swipe data yet
+        }
+    }
+    return false; // No assistant messages in chat
+}
+
+/**
  * Commits the tracker data from the last assistant message to be used as source for next generation.
  * This should be called when the user has replied to a message, ensuring all swipes of the next
  * response use the same committed context.
@@ -330,6 +369,22 @@ export function onCharacterChanged() {
     // Load chat-specific data when switching chats
     loadChatData();
 
+    // chat_metadata may not reflect the actual chat tail for branches, so
+    // loadChatData() may have just restored stale data from the parent chat.
+    // Override lastGeneratedData from the swipe store of the last assistant message.
+    // The message objects in the branch already carry their full swipe stores, making this authoritative.
+    // If no swipe data exists (e.g. branching at message 0, or a chat with no generations yet),
+    // null out lastGeneratedData and committedTrackerData so we don't display stale values from the parent chat.
+    const hadSwipeData = syncLastGeneratedDataFromSwipeStore(getContext().chat);
+    if (!hadSwipeData) {
+        lastGeneratedData.userStats = null;
+        lastGeneratedData.infoBox = null;
+        lastGeneratedData.characterThoughts = null;
+        committedTrackerData.userStats = null;
+        committedTrackerData.infoBox = null;
+        committedTrackerData.characterThoughts = null;
+    }
+
     // Don't call commitTrackerData() here - it would overwrite the loaded committedTrackerData
     // with data from the last message, which may be null/empty. The loaded committedTrackerData
     // already contains the committed state from when we last left this chat.
@@ -471,32 +526,17 @@ export function onMessageDeleted() {
         committedTrackerData.characterThoughts = null;
         // console.log('[RPG Companion] 🗑️ No assistant messages remain — cleared all tracker state.');
     } else {
-        const message = currentChat[lastAssistantIndex];
-        const swipeId = message.swipe_id || 0;
-        const swipeData = getSwipeData(message, swipeId);
-
-        if (swipeData) {
-            // Restore display state from the new tail message's active swipe.
-            lastGeneratedData.userStats = swipeData.userStats || null;
-            lastGeneratedData.infoBox = swipeData.infoBox || null;
-            // Normalise characterThoughts to string (backward compat with old object format).
-            if (swipeData.characterThoughts && typeof swipeData.characterThoughts === 'object') {
-                lastGeneratedData.characterThoughts = JSON.stringify(swipeData.characterThoughts, null, 2);
-            } else {
-                lastGeneratedData.characterThoughts = swipeData.characterThoughts || null;
-            }
-
-            // Sync stat bars.
-            if (swipeData.userStats) {
-                parseUserStats(swipeData.userStats);
-            }
-
-            // console.log('[RPG Companion] 🗑️ Restored display state from assistant message at index', lastAssistantIndex, 'swipe', swipeId);
-        } else {
-            // No swipe data for this message — clear display state.
+        // Restore display state from the new tail message's active swipe.
+        // If the message has no swipe data yet, null the fields so we
+        // don't show stale data from the deleted message.
+        const hadSwipeData = syncLastGeneratedDataFromSwipeStore(currentChat);
+        if (!hadSwipeData) {
             lastGeneratedData.userStats = null;
             lastGeneratedData.infoBox = null;
             lastGeneratedData.characterThoughts = null;
+            committedTrackerData.userStats = null;
+            committedTrackerData.infoBox = null;
+            committedTrackerData.characterThoughts = null;
             // console.log('[RPG Companion] 🗑️ No swipe data for last assistant message — cleared display state.');
         }
 

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -24,7 +24,7 @@ import {
     getSeparateGenerationId,
     incrementSeparateGenerationId
 } from '../../core/state.js';
-import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData, commitTrackerDataFromPriorMessage, mirrorToSwipeInfo } from '../../core/persistence.js';
+import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData, commitTrackerDataFromPriorMessage, inheritSwipeDataFromPriorMessage, mirrorToSwipeInfo } from '../../core/persistence.js';
 import { i18n } from '../../core/i18n.js';
 
 // Generation & Parsing
@@ -301,6 +301,13 @@ export async function onMessageReceived(data) {
             if (foundSpotifyUrl && extensionSettings.enableSpotifyMusic) {
                 // Just render the music player
                 renderMusicPlayer($musicPlayerContainer[0]);
+            }
+
+            // When auto-update is disabled,no tracker API call will run for this message. 
+            // Inherit the prior assistant message's tracker data into this swipe slot so that 
+            // commitTrackerDataFromPriorMessage can find a valid state next turn instead of nulling everything
+            if (!extensionSettings.autoUpdate || !isAwaitingNewMessage) {
+                inheritSwipeDataFromPriorMessage(lastMessage, chat.length - 1);
             }
         }
 

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -164,14 +164,6 @@ export function onMessageSent() {
     // Note: FAB spinning is NOT shown for together mode since no extra API request is made
     // The RPG data comes embedded in the main response
     // FAB spinning is handled by apiClient.js for separate/external modes when updateRPGData() is called
-
-    // For separate mode with auto-update disabled, commit from the prior assistant message's
-    // swipe store rather than lastGeneratedData to avoid ghost context from sibling swipes.
-    // At this point chat[chat.length - 1] is the user message, so search from before it.
-    if (extensionSettings.generationMode === 'separate' && !extensionSettings.autoUpdate) {
-        commitTrackerDataFromPriorMessage(chat.length - 1);
-        // console.log('[RPG Companion] 💾 SEPARATE MODE: Committed from prior assistant message (auto-update disabled)');
-    }
 }
 
 /**

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -302,7 +302,7 @@ export async function onMessageReceived(data) {
                 renderMusicPlayer($musicPlayerContainer[0]);
             }
 
-            // When auto-update is disabled,no tracker API call will run for this message. 
+            // When auto-update is disabled, no tracker API call will run for this message. 
             // Inherit the prior assistant message's tracker data into this swipe slot so that 
             // commitTrackerDataFromPriorMessage can find a valid state next turn instead of nulling everything
             if (!extensionSettings.autoUpdate && isAwaitingNewMessage) {

--- a/src/systems/integration/sillytavern.js
+++ b/src/systems/integration/sillytavern.js
@@ -21,7 +21,6 @@ import {
     updateLastGeneratedData,
     updateCommittedTrackerData,
     $musicPlayerContainer,
-    getSeparateGenerationId,
     incrementSeparateGenerationId
 } from '../../core/state.js';
 import { saveChatData, loadChatData, autoSwitchPresetForEntity, getSwipeData, commitTrackerDataFromPriorMessage, inheritSwipeDataFromPriorMessage, mirrorToSwipeInfo } from '../../core/persistence.js';


### PR DESCRIPTION
I'm a new user of this extension, so I'm not fully aware of the development history. I noticed that [a previous merged PR](https://github.com/SpicyMarinara/rpg-companion-sillytavern/pull/99) seems to have been made that should have addressed this issue already, but when examining the code, those changes were no longer present. Notably, there was no longer a MESSAGE_DELETED event handler. Apologies if there was a particular design reason to revert those changes and this PR is now redundant for those same reasons.

### Summary

This PR primarily fixes a bug where generating a new swipe would send the AI stale tracker context from the last generated swipe (creating issues with tracker state consistency) instead of from the last Assistant message, and adds several related improvements to swipe state management intended to pre-empt other similar potential bugs.

---

### Problems Fixed

**Ghost context on new swipes**
When swiping to generate a new AI response, the tracker context injected into the prompt reflected the outcome of the previously generated swipe rather than the world state before the current user message. This caused each sibling swipe to silently inherit state from a parallel timeline.

**Stat bars not updating on swipe navigation**
Navigating to an existing swipe did not update the numeric displays, showing values from the most recently generated swipe on all existing swipes instead of the data corresponding to that output.

**Tracker state not resetting on message deletion**
Deleting a message left the UI and committed context pointing at data from the deleted message rather than the new chat tail.

**Stale tracker display after branching**
Creating a branch at any point in the chat left the tracker UI showing data from the parent chat's tail rather than the branched chat's actual tail. This also affected `committedTrackerData`, meaning the first generation in the new branch would use ghost context from the parent.

---

### Changes

**state.js**
- Added `separateGenerationId` counter with `getSeparateGenerationId()` and `incrementSeparateGenerationId()` exports — used to invalidate stale separate-mode generation results in cases where a message deletion occurs **during** a separate-mode tracker update. This prevents data associated with a non-existent message from overwriting the data associated with the new chat tail.

**persistence.js**
- Added `getSwipeData(message, swipeId)` — canonical read path that checks `message.extra` first and falls back to `message.swipe_info[n].extra`, covering both in-session and post-reload access
- Added `commitTrackerDataFromPriorMessage(currentMessageIndex)` — walks `chat` backward from the given index to find the prior assistant message and loads its active swipe data into `committedTrackerData`; explicitly nulls all fields when no prior assistant message exists. This makes sure that committed data is always from the last assistant message and not the current one when swiping.
- Added `inheritSwipeDataFromPriorMessage(message, messageIndex)` — when a message is received with auto-update disabled, copies the nearest prior assistant message's active swipe data into the current message's swipe slot. Guards against overwriting existing data. This ensures `commitTrackerDataFromPriorMessage` can always find a valid state on the next turn rather than nulling everything, allowing tracker state to persist across turns where the user chose not to update it.
- Updated `updateMessageSwipeData()` to mirror writes into `message.swipe_info[swipeId].extra` so non-active swipe data survives page reloads

**sillytavern.js**
- Added private helper `syncLastGeneratedDataFromSwipeStore(currentChat)` — walks `chat` backward to find the last assistant message, reads its active swipe via `getSwipeData`, writes into `lastGeneratedData`, and calls `parseUserStats`; returns `false` if no assistant message or no swipe data exists
- Updated `commitTrackerData()` to use `getSwipeData()` instead of bare `message.extra` reads
- Updated `onMessageSwiped()` to call `parseUserStats()` unconditionally on swipe navigation so stat bars always reflect the loaded swipe. Previously, a guard prevented `parseUserStats()` from being called on swipe navigation, leaving stat bars showing values from the most recently generated swipe regardless of which swipe was active. Manual stat edits are saved to the swipe data, which is now the authority, so navigating between swipes will not reset edits even if this guard is removed.
- Updated `onMessageSent()` separate mode / auto-update disabled branch to use `commitTrackerDataFromPriorMessage()` instead of copying `lastGeneratedData`
- Updated `onMessageReceived()` to call `inheritSwipeDataFromPriorMessage()` in separate/external mode when auto-update is disabled to ensure swipe slots that never trigger a tracker API call still carry forward a valid tracker state rather than leaving the slot empty.
- Updated `onCharacterChanged()` to call `syncLastGeneratedDataFromSwipeStore()` after `loadChatData()`; when no swipe data exists, nulls both `lastGeneratedData` and `committedTrackerData` before rendering — ensures branches at any point display and generate from the correct state rather than inheriting stale values from the parent chat
- Added `onMessageDeleted()` handler — restores `lastGeneratedData`, syncs stat bars, updates committed context via `commitTrackerDataFromPriorMessage()`, re-renders all panels, and calls `incrementSeparateGenerationId()` to cancel any pending or in-flight separate-mode generation.

**injector.js**
- Replaced `lastGeneratedData → committedTrackerData` copy blocks in both separate/external and together mode commit paths with `commitTrackerDataFromPriorMessage()`

**apiClient.js**
- `updateRPGData()` now accepts an optional `generationId` parameter
- Added a post-await guard: if `generationId` is set and no longer matches the current counter, the result is silently discarded instead of overwriting UI state — prevents a race condition where a message deletion completes while a separate-mode API call is in-flight

**index.js**
- Imported and registered `onMessageDeleted` against `event_types.MESSAGE_DELETED`

### Key Patterns Established

1. **`committedTrackerData` is always loaded from the swipe store**, never copied from `lastGeneratedData`. From my understanding, `lastGeneratedData` was intended to be for display only, anyway.

2. **Data is stored for all swipes, on all messages, individually and persistently, and the swipe store is authoritative**. Every swipe has its own tracker state, and these states are saved to file, ensuring that it is possible to branch at or delete your way to any previous message and work from that message's saved tracker state.

---

This PR touches several files due to how broadly the original commit path was used, but I attempted to limit scope and maintain existing conventions. Every change I made was for the purpose of establishing and maintaining the above two design patterns. I believe using an explicit helper function to ensure committed data always belongs to the last assistant message is more robust than the current flag-based system and that the other changes to normalize the commit method are justified, but again, I'll understand if I'm missing some development context.

Re: Together-mode generations, my current API solution makes testing using this mode difficult, and Separate is my primary generation mode. Together generations should have already been pretty resistant to the main bug this PR resolves, but I edited its methods for the sake of consistency as well. If there are any problems with the Together mode changes that I missed, I'm happy to revert them. I'm very flexible given the ambitious nature of this request. Also let me know if these changes have unforeseen consequences with how data is stored for Together mode, as I'm not 100% sure how the data extraction from within a single message works in practice.