### PR TITLE
replace filter tags with ofilter to avoid HTML/SVG collision

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -30,7 +30,7 @@ export let extensionSettings = {
     customDialogueColoringPrompt: '', // Custom dialogue coloring prompt text (empty = use default)
     enableDeceptionSystem: false, // Enable deception tracking with <lie> tags
     customDeceptionPrompt: '', // Custom deception prompt text (empty = use default)
-    enableOmniscienceFilter: false, // Enable omniscience filter with <filter> tags
+    enableOmniscienceFilter: false, // Enable omniscience filter with <ofilter> tags
     customOmnisciencePrompt: '', // Custom omniscience filter prompt text (empty = use default)
     enableCYOA: false, // Enable "Choose Your Own Adventure" formatting with action choices
     customCYOAPrompt: '', // Custom CYOA prompt text (empty = use default)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -359,7 +359,7 @@
     "template.promptsEditor.deceptionPrompt.title": "Deception System Prompt",
     "template.promptsEditor.deceptionPrompt.note": "Injected when \"Enable Deception System\" is enabled. Instructs AI to mark lies and deceptions with hidden tags.",
     "template.promptsEditor.omnisciencePrompt.title": "Omniscience Filter Prompt",
-    "template.promptsEditor.omnisciencePrompt.note": "Injected when \"Enable Omniscience Filter\" is enabled. Instructs AI to separate information the player character cannot perceive into hidden filter tags.",
+    "template.promptsEditor.omnisciencePrompt.note": "Injected when \"Enable Omniscience Filter\" is enabled. Instructs AI to separate information the player character cannot perceive into hidden <ofilter> tags.",
     "template.promptsEditor.cyoaPrompt.title": "CYOA Prompt",
     "template.promptsEditor.cyoaPrompt.note": "Injected when \"Enable CYOA\" is enabled. Instructs AI to end responses with numbered action choices. Uses very high priority (depth 102) to ensure it's the last instruction.",
     "template.promptsEditor.spotifyPrompt.title": "Spotify Music Prompt",

--- a/src/systems/generation/promptBuilder.js
+++ b/src/systems/generation/promptBuilder.js
@@ -37,9 +37,9 @@ export const DEFAULT_DECEPTION_PROMPT = `When a character is lying or deceiving,
  * Default Omniscience Filter prompt text
  * This instructs the AI to separate information the player character cannot perceive
  */
-export const DEFAULT_OMNISCIENCE_FILTER_PROMPT = `You must strictly separate what the player can directly perceive from what they cannot. They should only read limited narrative content that their persona can actually see, hear, smell, touch, or otherwise directly sense. Before writing any narrative content that involves events, actions, or details the player directly cannot perceive (because they're not looking, too far away, behind them, in another room, happening silently, include NPCs' internal thoughts, etc.), you absolutely must output that hidden information inside a <filter> tag using this exact format:
-<filter event="[Brief description of what is happening that the player cannot perceive]" reason="[Why the player character cannot perceive this - e.g., 'behind them', 'in another room', 'too quiet to hear', 'focused elsewhere']"/>
-Example: <filter event="Zandik quietly takes the key from the table and slips out the back door" reason="Zandik is behind Mari, who is absorbed in reading, and he moves silently"/> You hear a faint click from somewhere behind you, but when you glance up from your newspaper, the room seems unchanged.`;
+export const DEFAULT_OMNISCIENCE_FILTER_PROMPT = `You must strictly separate what the player can directly perceive from what they cannot. They should only read limited narrative content that their persona can actually see, hear, smell, touch, or otherwise directly sense. Before writing any narrative content that involves events, actions, or details the player directly cannot perceive (because they're not looking, too far away, behind them, in another room, happening silently, include NPCs' internal thoughts, etc.), you absolutely must output that hidden information inside a <ofilter> tag using this exact format:
+<ofilter event="[Brief description of what is happening that the player cannot perceive]" reason="[Why the player character cannot perceive this - e.g., 'behind them', 'in another room', 'too quiet to hear', 'focused elsewhere']"/>
+Example: <ofilter event="Zandik quietly takes the key from the table and slips out the back door" reason="Zandik is behind Mari, who is absorbed in reading, and he moves silently"/> You hear a faint click from somewhere behind you, but when you glance up from your newspaper, the room seems unchanged.`;
 
 
 /**

--- a/template.html
+++ b/template.html
@@ -1050,7 +1050,7 @@
                     <i class="fa-solid fa-eye-slash"></i> <span data-i18n-key="template.promptsEditor.omnisciencePrompt.title">Omniscience Filter Prompt</span>
                 </label>
                 <small style="display: block; margin-bottom: 8px; color: #888; font-size: 11px;" data-i18n-key="template.promptsEditor.omnisciencePrompt.note">
-                    Injected when "Enable Omniscience Filter" is enabled. Instructs AI to separate information the player character cannot perceive into hidden filter tags.
+                    Injected when "Enable Omniscience Filter" is enabled. Instructs AI to separate information the player character cannot perceive into hidden &lt;ofilter&gt; tags.
                 </small>
                 <textarea id="rpg-prompt-omniscience" class="rpg-prompt-textarea" rows="6"></textarea>
                 <button class="menu_button rpg-restore-prompt-btn" data-prompt="omniscience" style="margin-top: 8px;">


### PR DESCRIPTION
Previously the Omniscience Filter used a self-closing `<filter>` tag. After some consideration, this may collide with HTML/CSV tag, and cause improper trimming of text. Renamed it to `<ofilter>` instead to make sure it's unique. This change will most likely require restoring of default Omniscience Filter prompt.